### PR TITLE
Feat/10/router

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@
 */yarn-error.log*
 
 .idea
+.vscode

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -7,6 +7,13 @@
     <meta name="theme-color" content="#000000" />
     <meta name="description" content="Woowa Kiosk" />
     <title>Woowa Kiosk</title>
+
+    <link
+      rel="stylesheet"
+      as="style"
+      crossorigin
+      href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.5/dist/web/static/pretendard-dynamic-subset.css"
+    />
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,11 +2,13 @@ import { ThemeProvider } from 'styled-components'
 
 import GlobalStyle from 'src/styles/GlobalStyles'
 import { theme } from 'src/styles/theme'
+import Router from './Router'
 
 function App() {
   return (
     <ThemeProvider theme={theme}>
       <GlobalStyle />
+        <Router />
     </ThemeProvider>
   )
 }

--- a/frontend/src/Router.tsx
+++ b/frontend/src/Router.tsx
@@ -1,0 +1,15 @@
+import Route from './lib/router/Route'
+import { Routes } from './lib/router/Routes'
+import Home from './pages/Home'
+import Main from './pages/Main'
+
+const Router = () => {
+  return (
+    <Routes>
+      <Route path="/" component={<Home />} />
+      <Route path="/main" component={<Main />} />
+    </Routes>
+  )
+}
+
+export default Router

--- a/frontend/src/lib/router/Link.tsx
+++ b/frontend/src/lib/router/Link.tsx
@@ -1,0 +1,27 @@
+import React, { useContext } from 'react'
+import { RouteContext } from './Routes'
+
+interface Props {
+  to: string
+  children: React.ReactNode
+  className?: string
+}
+
+const Link = ({ className, to, children }: Props) => {
+  const { movePath } = useContext(RouteContext)
+
+  const preventReload = (e: React.MouseEvent<HTMLAnchorElement>) => {
+    e.preventDefault()
+
+    window.history.pushState(to, '', to)
+    movePath(to)
+  }
+
+  return (
+    <a className={className} href={to} onClick={preventReload}>
+      {children}
+    </a>
+  )
+}
+
+export default Link

--- a/frontend/src/lib/router/Route.tsx
+++ b/frontend/src/lib/router/Route.tsx
@@ -1,0 +1,15 @@
+import { useContext } from 'react'
+import { RouteContext } from './Routes'
+
+interface Props {
+  path: string
+  component: JSX.Element
+}
+
+const Route = ({ path, component }: Props) => {
+  const { path: currentPath } = useContext(RouteContext)
+
+  return currentPath === path ? component : null
+}
+
+export default Route

--- a/frontend/src/lib/router/Routes.tsx
+++ b/frontend/src/lib/router/Routes.tsx
@@ -1,0 +1,48 @@
+import { createContext, FC, useEffect, useMemo, useState } from 'react'
+
+interface Route {
+  path: string
+  movePath: (newPath: string) => void
+}
+
+export const RouteContext = createContext<Route>({
+  path: '',
+  movePath: () => {},
+})
+
+interface Props {
+  children: React.ReactNode
+}
+
+const RouteProvider: FC<Props> = ({ children }) => {
+  const [path, setPath] = useState(window.location.pathname)
+
+  const movePath = (newPath: string) => {
+    setPath(newPath)
+  }
+
+  useEffect(() => {
+    const onPopState = (e: PopStateEvent) => {
+      setPath(e.state || '/')
+    }
+
+    window.addEventListener('popstate', onPopState)
+
+    return () => {
+      window.removeEventListener('popstate', onPopState)
+    }
+  }, [])
+
+  return (
+    <RouteContext.Provider
+      value={{
+        path,
+        movePath,
+      }}
+    >
+      {children}
+    </RouteContext.Provider>
+  )
+}
+
+export { RouteProvider as Routes }

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,0 +1,60 @@
+import Link from 'src/lib/router/Link'
+import styled from 'styled-components'
+
+const Home = () => {
+  return <Wrapper></Wrapper>
+}
+
+export default Home
+
+const Wrapper = styled.div`
+  margin-top: 417px;
+  padding: 0 60px;
+`
+
+const Title = styled.h1`
+  font-size: 72px;
+  font-weight: 600;
+  color: ${({ theme }) => theme.color.black};
+`
+
+const Desc = styled.p`
+  margin-top: 24px;
+  font-size: 36px;
+  color: ${({ theme }) => theme.color.black};
+`
+
+const ButtonWrapper = styled.div`
+  margin-top: 157px;
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  gap: 30px;
+`
+
+const Button = styled(Link)`
+  width: 465px;
+  height: 490px;
+
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+
+  background-color: ${({ theme }) => theme.color.gray100};
+  border-radius: 24px;
+
+  color: ${({ theme }) => theme.color.black};
+`
+
+const ButtonTitle = styled.p`
+  font-weight: 600;
+  font-size: 64px;
+  line-height: 140%;
+`
+
+const ButtonDesc = styled.p`
+  margin-top: 24px;
+  font-size: 36px;
+  line-height: 140%;
+`

--- a/frontend/src/pages/Main.tsx
+++ b/frontend/src/pages/Main.tsx
@@ -1,0 +1,7 @@
+import React from 'react'
+
+const Main = () => {
+  return <div>Main</div>
+}
+
+export default Main

--- a/frontend/src/styles/GlobalStyles.tsx
+++ b/frontend/src/styles/GlobalStyles.tsx
@@ -17,6 +17,7 @@ const customReset = css`
 
   a {
     text-decoration: none;
+    color: ${({ theme }) => theme.color.black};
   }
 
   img {
@@ -37,8 +38,16 @@ const GlobalStyle = createGlobalStyle`
   html,
   body{
     font-family: Pretendard, -apple-system, BlinkMacSystemFont, system-ui, Roboto, "Helvetica Neue", "Segoe UI", "Apple SD Gothic Neo", "Noto Sans KR", "Malgun Gothic", "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", sans-serif;
-    font-display: fallback;
+    
+    max-width: 1080px;
+    width: 100%;
+    height: 1920px;
+    margin: 0 auto;
+
+    letter-spacing: -0.41px;
   }
+
+  
 
 `
 


### PR DESCRIPTION
## 📑 개요

라우터 구현

## 💬 작업 내용

Routes 컴포넌트
- Context API를 활용해 해당 컴포넌트에서 사이트의 `path`를 관리합니다.

Route 컴포넌트 
- Routes (RouteContext)의 `path`와 Route 컴포넌트에 prop으로 전달해준 `path`를 비교해서 같으면 페이지를 렌더링합니다.

Link 컴포넌트
- RouteContext의 `path`를 변경합니다.

## 🕰 실제 소요 시간

3h

## 📎 관련 이슈

close #10

## 특이 사항

Thanks to Jooam!