### PR TITLE
Feat/33/cart

### DIFF
--- a/backend/src/categories/categories.entity.ts
+++ b/backend/src/categories/categories.entity.ts
@@ -12,6 +12,6 @@ export class Category extends BaseEntity {
   @Column()
   en_name: string
 
-  @OneToMany(() => Product, (product) => product.category, { eager: true })
+  @OneToMany(() => Product, (product) => product.category)
   products: Product[]
 }

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -9,6 +9,7 @@ async function bootstrap() {
   const port = configService.get('PORT')
 
   app.setGlobalPrefix('api')
+  app.enableCors()
 
   await app.listen(port)
   Logger.log(`Application running on port ${port}`)

--- a/backend/src/order-to-product/order-to-product.entity.ts
+++ b/backend/src/order-to-product/order-to-product.entity.ts
@@ -10,6 +10,12 @@ export class OrderToProduct extends BaseEntity {
   @Column()
   count: number
 
+  @Column()
+  order_id: number
+
+  @Column()
+  product_id: number
+
   @ManyToOne(() => Order, (order) => order.orderToProducts)
   @JoinColumn({ name: 'order_id' })
   order: Order

--- a/backend/src/orders/orders.controller.ts
+++ b/backend/src/orders/orders.controller.ts
@@ -19,7 +19,6 @@ export class OrdersController {
       const orderHistory = await this.ordersService.create(order)
       return orderHistory
     } catch (e) {
-      console.log(e)
       throw new HttpException(ERROR_MESSAGE.INTERNAL_SERVER_ERROR, HttpStatus.INTERNAL_SERVER_ERROR)
     }
   }

--- a/backend/src/orders/orders.service.ts
+++ b/backend/src/orders/orders.service.ts
@@ -34,7 +34,7 @@ export class OrdersService {
     return newOrder
   }
 
-  async createOrderToProduct(products: OrdersProduct[], newOrder: Order): Promise<void> {
+  async createOrderToProduct(products: OrdersProduct[], orderId: number): Promise<void> {
     const productCreateList = products.map(async (productInfo) => {
       const product = await this.productRepository.findOne({
         where: {
@@ -43,7 +43,7 @@ export class OrdersService {
       })
 
       await this.orderToProductRepository.save({
-        order: newOrder,
+        order_id: orderId,
         product: product,
         count: productInfo.count,
       })
@@ -64,7 +64,7 @@ export class OrdersService {
     const { products } = order
     const newOrder = await this.createOrder(order)
     const orderNumber = await this.findOrderNumber()
-    this.createOrderToProduct(products, newOrder)
+    this.createOrderToProduct(products, newOrder.id)
 
     return { ...newOrder, order_number: orderNumber }
   }

--- a/backend/src/products/products.controller.ts
+++ b/backend/src/products/products.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, HttpException, HttpStatus, Post, UsePipes } from '@nestjs/common'
+import { Body, Controller, Get, HttpException, HttpStatus, Param, Post, UsePipes } from '@nestjs/common'
 import { ValidationPipe } from 'src/pipes/validation.pipe'
 import { ERROR_MESSAGE } from 'src/utils/error-message'
 import { CreateProductRequestDto } from './dto/create-product.dto'
@@ -13,6 +13,11 @@ export class ProductsController {
   @Get()
   findAll(): Promise<Product[]> {
     return this.productsService.findAll()
+  }
+
+  @Get(':id')
+  findById(@Param('id') id: string): Promise<Product[]> {
+    return this.productsService.findOneById(+id)
   }
 
   @Post()

--- a/backend/src/products/products.entity.ts
+++ b/backend/src/products/products.entity.ts
@@ -27,6 +27,14 @@ export class Product extends BaseEntity {
   })
   is_famous: boolean
 
+  @Column({
+    default: false,
+  })
+  is_soldout: boolean
+
+  @Column()
+  category_id: number
+
   @ManyToOne(() => Category, (category) => category.products, { eager: false })
   @JoinColumn({ name: 'category_id' })
   category: Category

--- a/backend/src/products/products.service.ts
+++ b/backend/src/products/products.service.ts
@@ -15,6 +15,10 @@ export class ProductsService {
     return await this.productsRepository.find()
   }
 
+  async findOneById(categoryId: number): Promise<Product[]> {
+    return await this.productsRepository.find({ where: { category_id: categoryId } })
+  }
+
   async create(product: CreateProductRequestDto): Promise<void> {
     const newProduct = this.productsRepository.create(product)
     await this.productsRepository.save(newProduct)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,11 +1,17 @@
+import { useLayoutEffect } from 'react'
 import { ThemeProvider } from 'styled-components'
 
 import GlobalStyle from 'src/styles/GlobalStyles'
 import { theme } from 'src/styles/theme'
 import Router from './Router'
 import InternationalizationProvider from 'src/contexts/InternationalizationContext'
+import { initAxiosConfig } from './api'
 
 function App() {
+  useLayoutEffect(() => {
+    initAxiosConfig()
+  }, [])
+
   return (
     <InternationalizationProvider>
       <ThemeProvider theme={theme}>

--- a/frontend/src/api/category/category.ts
+++ b/frontend/src/api/category/category.ts
@@ -1,0 +1,8 @@
+import axios from 'axios'
+import { CategoryType } from 'src/types/api/category'
+
+export const getCategoriesAPI = async (): Promise<CategoryType[]> => {
+  const { data } = await axios.get('/categories')
+
+  return data
+}

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -1,0 +1,6 @@
+import axios from 'axios'
+
+export const initAxiosConfig = () => {
+  axios.defaults.baseURL = process.env.REACT_APP_API_BASE_URL
+  axios.defaults.timeout = 3000
+}

--- a/frontend/src/api/product/product.ts
+++ b/frontend/src/api/product/product.ts
@@ -1,0 +1,8 @@
+import axios from 'axios'
+import { ProductType } from 'src/types/api/product'
+
+export const getProductsAPI = async (categoryId: number): Promise<ProductType[]> => {
+  const { data } = await axios.get(`/products/${categoryId}`)
+
+  return data
+}

--- a/frontend/src/components/MainPage/Cart/Cart.tsx
+++ b/frontend/src/components/MainPage/Cart/Cart.tsx
@@ -1,8 +1,39 @@
-import React from 'react'
+import React, { useContext } from 'react'
+import Button from 'src/components/common/Button/Button'
+import { useCartList, useCartSummary } from 'src/contexts/CartContext'
+import useTranslation from 'src/hooks/useTranslation'
+import { priceToString } from 'src/utils/priceUtil'
 import styled from 'styled-components'
+import CartItem from './CartItem'
 
 const Cart = () => {
-  return <Wrapper></Wrapper>
+  const t = useTranslation('main')
+  const cartList = useCartList()
+  const { count, price } = useCartSummary()
+
+  return (
+    <Wrapper>
+      <CartListWrapper>
+        {cartList.map((cartItem) => (
+          <CartItem key={cartItem.id} cartItem={cartItem} />
+        ))}
+      </CartListWrapper>
+      <CartListSummaryWrapper>
+        <CartListCount>
+          {t('totalCount')} : {count}
+        </CartListCount>
+        <CartListPrice>
+          {t('price')} : <span className="price">{priceToString(price)}</span>
+        </CartListPrice>
+      </CartListSummaryWrapper>
+      <ButtonWrapper>
+        <Button bgColor="black">{t('cancel')}</Button>
+        <Button width="340px" bgColor="red">
+          {t('order')}
+        </Button>
+      </ButtonWrapper>
+    </Wrapper>
+  )
 }
 
 export default Cart
@@ -19,4 +50,44 @@ const Wrapper = styled.div`
 
   background: ${({ theme }) => theme.color.gray800};
   border-radius: 24px 24px 0px 0px;
+`
+
+const CartListWrapper = styled.div`
+  min-height: 200px;
+  display: flex;
+  gap: 24px;
+`
+
+const CartListSummaryWrapper = styled.div`
+  margin-top: 36px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+`
+
+const ButtonWrapper = styled.div`
+  margin-top: 36px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+`
+
+const CartListCount = styled.p`
+  font-weight: 600;
+  font-size: 32px;
+  line-height: 38px;
+
+  color: ${({ theme }) => theme.color.white};
+`
+
+const CartListPrice = styled.p`
+  font-weight: 600;
+  font-size: 40px;
+  line-height: 48px;
+
+  color: ${({ theme }) => theme.color.white};
+
+  .price {
+    color: ${({ theme }) => theme.color.red};
+  }
 `

--- a/frontend/src/components/MainPage/Cart/Cart.tsx
+++ b/frontend/src/components/MainPage/Cart/Cart.tsx
@@ -1,0 +1,22 @@
+import React from 'react'
+import styled from 'styled-components'
+
+const Cart = () => {
+  return <Wrapper></Wrapper>
+}
+
+export default Cart
+
+const Wrapper = styled.div`
+  position: absolute;
+  left: 0;
+  bottom: 0;
+
+  width: 100%;
+  height: 525px;
+
+  padding: 32px 42px;
+
+  background: ${({ theme }) => theme.color.gray800};
+  border-radius: 24px 24px 0px 0px;
+`

--- a/frontend/src/components/MainPage/Cart/CartItem.tsx
+++ b/frontend/src/components/MainPage/Cart/CartItem.tsx
@@ -1,0 +1,74 @@
+import React, { FC, useContext } from 'react'
+import styled from 'styled-components'
+
+import { Image } from 'src/components/common/Image/Image'
+import { CartItemType } from 'src/contexts/CartContext'
+import { InternationalizationContext } from 'src/contexts/InternationalizationContext'
+import Icon from 'src/components/common/Icon/Icon'
+
+interface Props {
+  cartItem: CartItemType
+}
+
+const CartItem: FC<Props> = ({ cartItem }) => {
+  const { language } = useContext(InternationalizationContext)
+  return (
+    <Wrapper>
+      <RemoveIcon name="iconCircleX" size={40} />
+      <Image src={cartItem.thumbnail} width={120} height={120} />
+      <ProductName>
+        {language === 'KR' && cartItem.kr_name}
+        {language === 'EN' && cartItem.en_name}
+      </ProductName>
+      <CountWrapper>
+        <Icon name="iconCircleMinus" />
+        <Count>{cartItem.count}</Count>
+        <Icon name="iconCirclePlus" />
+      </CountWrapper>
+    </Wrapper>
+  )
+}
+
+export default CartItem
+
+const Wrapper = styled.div`
+  position: relative;
+  width: 160px;
+  height: 200px;
+
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+
+  background-color: ${({ theme }) => theme.color.gray100};
+  border-radius: 24px;
+`
+
+const ProductName = styled.p`
+  margin-top: 4px;
+  font-weight: 600;
+  font-size: 16px;
+  line-height: 19px;
+  color: ${({ theme }) => theme.color.black};
+`
+
+const CountWrapper = styled.div`
+  margin-top: 8px;
+  display: flex;
+  justify-content: center;
+  gap: 20px;
+`
+
+const Count = styled.p`
+  font-weight: 600;
+  font-size: 32px;
+  line-height: 38px;
+
+  color: ${({ theme }) => theme.color.black};
+`
+
+const RemoveIcon = styled(Icon)`
+  position: absolute;
+  top: -5px;
+  right: -8px;
+`

--- a/frontend/src/components/MainPage/CategoryTabs/CategoryTabs.tsx
+++ b/frontend/src/components/MainPage/CategoryTabs/CategoryTabs.tsx
@@ -1,16 +1,9 @@
-import { FC, useContext, useState } from 'react'
+import { FC, useContext, useEffect, useState } from 'react'
+import { getCategoriesAPI } from 'src/api/category/category'
 import { InternationalizationContext } from 'src/contexts/InternationalizationContext'
+import { CategoryType } from 'src/types/api/category'
 import styled from 'styled-components'
 import Button from '../../common/Button/Button'
-
-const DUMMY_CATEGORY = [
-  { id: 1, kr_name: '커피', en_name: 'Coffee' },
-  { id: 2, kr_name: '디카페인', en_name: 'Non-Coffee' },
-  { id: 3, kr_name: '티', en_name: 'Tea' },
-  { id: 4, kr_name: '에이드', en_name: 'Ade' },
-  { id: 5, kr_name: '주스', en_name: 'Juice' },
-  { id: 6, kr_name: '디저트', en_name: 'Dessert' },
-]
 
 interface Props {
   selected: number
@@ -18,11 +11,21 @@ interface Props {
 }
 
 const CategoryTabs: FC<Props> = ({ selected, onClickCategory }) => {
+  const [categories, setCategories] = useState<CategoryType[]>([])
   const { language } = useContext(InternationalizationContext)
+
+  const getCategories = async () => {
+    const data = await getCategoriesAPI()
+    setCategories(data)
+  }
+
+  useEffect(() => {
+    getCategories()
+  }, [])
 
   return (
     <Wrapper>
-      {DUMMY_CATEGORY.map((category) => (
+      {categories.map((category) => (
         <Button
           key={category.id}
           bgColor={selected === category.id ? 'black' : 'gray100'}

--- a/frontend/src/components/MainPage/CategoryTabs/CategoryTabs.tsx
+++ b/frontend/src/components/MainPage/CategoryTabs/CategoryTabs.tsx
@@ -25,7 +25,7 @@ const CategoryTabs: FC<Props> = ({ selected, onClickCategory }) => {
       {DUMMY_CATEGORY.map((category) => (
         <Button
           key={category.id}
-          bgColor={selected === category.id ? 'gray800' : 'gray100'}
+          bgColor={selected === category.id ? 'black' : 'gray100'}
           onClick={() => onClickCategory(category.id)}
         >
           {language === 'KR' && category.kr_name}

--- a/frontend/src/components/MainPage/MenuList/MenuList.tsx
+++ b/frontend/src/components/MainPage/MenuList/MenuList.tsx
@@ -1,41 +1,10 @@
-import { FC, useContext } from 'react'
+import { FC, useContext, useEffect, useState } from 'react'
+import { getProductsAPI } from 'src/api/product/product'
 import { InternationalizationContext } from 'src/contexts/InternationalizationContext'
-import { CategoryType } from 'src/types/api/category'
+
 import { ProductType } from 'src/types/api/product'
 import styled from 'styled-components'
 import Menu from '../Menu/Menu'
-
-const DUMMY_DATA: CategoryType[] = [
-  {
-    id: 1,
-    kr_name: '커피',
-    en_name: 'coffee',
-    products: [
-      {
-        id: 1,
-        kr_name: '아메리카노',
-        en_name: 'americano',
-        price: 2800,
-        option: {},
-        thumbnail:
-          'http://www.mmthcoffee.com/data/file/mm_coffee/thumb-3546841901_fWNqCpj8_143c53926bf1eab4f92bda344722234f830269e0_216x216.png',
-        is_famous: false,
-        is_soldout: false,
-      },
-      {
-        id: 2,
-        kr_name: '아몬드 아메리카노',
-        en_name: 'almond americano',
-        price: 3100,
-        option: {},
-        thumbnail:
-          'http://www.mmthcoffee.com/data/file/mm_coffee/thumb-3546841901_1HBFIxl4_0d724e60d863d7144674ca4879dadb2604ef8371_216x216.png',
-        is_famous: false,
-        is_soldout: false,
-      },
-    ],
-  },
-]
 
 interface Props {
   selected: number
@@ -43,14 +12,16 @@ interface Props {
 
 const MenuList: FC<Props> = ({ selected }) => {
   const { language } = useContext(InternationalizationContext)
+  const [menuList, setMenuList] = useState<ProductType[]>([])
 
-  const getFilteredMenuList = (selected: number) => {
-    const categoryData = DUMMY_DATA.filter((category) => category.id === selected)
-
-    if (categoryData.length) return categoryData[0].products
-    return []
+  const getMenuList = async (selected: number) => {
+    const data = await getProductsAPI(selected)
+    setMenuList(data)
   }
-  const menuList = getFilteredMenuList(selected) || []
+
+  useEffect(() => {
+    getMenuList(selected)
+  }, [selected])
 
   return (
     <Wrapper>

--- a/frontend/src/components/common/Slider/Slider.tsx
+++ b/frontend/src/components/common/Slider/Slider.tsx
@@ -1,0 +1,67 @@
+import React, { FC, useEffect, useRef, useState } from 'react'
+import styled from 'styled-components'
+
+interface Props {
+  imgList: string[]
+  delay?: number
+}
+
+const Slider: FC<Props> = ({ imgList, delay = 2500 }) => {
+  const [index, setIndex] = useState(0)
+  const timeoutRef = useRef<any>(null)
+
+  const resetTimeout = () => {
+    if (!timeoutRef.current) return
+
+    clearTimeout(timeoutRef.current)
+  }
+
+  useEffect(() => {
+    resetTimeout()
+    timeoutRef.current = setTimeout(
+      () => setIndex((prevIndex) => (prevIndex === imgList.length - 1 ? 0 : prevIndex + 1)),
+      delay,
+    )
+
+    return () => {
+      resetTimeout()
+    }
+  }, [index])
+
+  return (
+    <SliderWrapper>
+      <SliderShow className="slideshowSlider" index={index}>
+        {imgList.map((img, idx) => (
+          <Slide key={idx}>
+            <img src={img} alt={`slider-${idx}`} />
+          </Slide>
+        ))}
+      </SliderShow>
+    </SliderWrapper>
+  )
+}
+
+export default Slider
+
+const SliderWrapper = styled.div`
+  margin: 0 auto;
+  overflow: hidden;
+  width: 1080px;
+`
+
+const SliderShow = styled.div<{ index: number }>`
+  white-space: nowrap;
+  transition: ease 1s;
+  transform: ${({ index }) => `translate3d(${-index * 100}%, 0, 0)`};
+`
+
+const Slide = styled.div`
+  display: inline-block;
+  width: 100%;
+  height: 300px;
+
+  img {
+    width: 100%;
+    height: 100%;
+  }
+`

--- a/frontend/src/components/common/Slider/Slider.tsx
+++ b/frontend/src/components/common/Slider/Slider.tsx
@@ -58,7 +58,7 @@ const SliderShow = styled.div<{ index: number }>`
 const Slide = styled.div`
   display: inline-block;
   width: 100%;
-  height: 300px;
+  height: 350px;
 
   img {
     width: 100%;

--- a/frontend/src/contexts/CartContext.tsx
+++ b/frontend/src/contexts/CartContext.tsx
@@ -1,0 +1,99 @@
+import { createContext, FC, useContext, useMemo, useRef, useState } from 'react'
+import { ProductType } from 'src/types/api/product'
+
+export interface CartItemType extends ProductType {
+  cartId: number
+  count: number
+}
+
+export const CartContext = createContext<CartItemType[]>([])
+export const CartActionContext = createContext<any>({})
+
+const MAX_COUNT = 10
+const MIN_COUNT = 1
+
+interface Props {
+  children: React.ReactNode
+}
+
+// TODO : 옵션에 따른 아이템 분기처리
+const CartProvider: FC<Props> = ({ children }) => {
+  const [cartList, setCartList] = useState<CartItemType[]>([])
+  const idRef = useRef(0)
+
+  const actions = useMemo(
+    () => ({
+      // TODO : 옵션에 따른 아이템 분기처리
+      add(cartItem: CartItemType) {
+        const cartId = idRef.current++
+        setCartList((prev) => [
+          ...prev,
+          {
+            ...cartItem,
+            cartId,
+          },
+        ])
+      },
+      // TODO : 옵션에 따른 아이템 분기처리
+      remove(id: number) {
+        setCartList((prev) => prev.filter((item) => item.id !== id))
+      },
+      countUp(id: number) {
+        setCartList((prev) =>
+          prev.map((item) =>
+            item.id === id && item.count < MAX_COUNT
+              ? {
+                  ...item,
+                  count: item.count + 1,
+                }
+              : item,
+          ),
+        )
+      },
+      countDown(id: number) {
+        setCartList((prev) =>
+          prev.map((item) =>
+            item.id === id && item.count > MIN_COUNT
+              ? {
+                  ...item,
+                  count: item.count - 1,
+                }
+              : item,
+          ),
+        )
+      },
+    }),
+    [],
+  )
+
+  return (
+    <CartActionContext.Provider value={actions}>
+      <CartContext.Provider value={cartList}>{children}</CartContext.Provider>
+    </CartActionContext.Provider>
+  )
+}
+
+export const useCartList = () => {
+  const value = useContext(CartContext)
+
+  return value
+}
+
+export const useCartSummary = () => {
+  const value = useContext(CartContext)
+
+  const count = value.reduce((acc, item) => acc + item.count, 0)
+  const price = value.reduce((acc, item) => acc + item.price * item.count, 0)
+  return {
+    count,
+    price,
+  }
+}
+
+export const useCartAction = () => {
+  const value = useContext(CartActionContext)
+
+  return value
+}
+
+export default CartProvider

--- a/frontend/src/i18n/EN/main.json
+++ b/frontend/src/i18n/EN/main.json
@@ -1,4 +1,8 @@
 {
   "back": "back",
-  "title": "Order"
+  "title": "Order",
+  "cancel": "Cancel",
+  "order": "Order",
+  "totalCount": "Total Count",
+  "price": "Price"
 }

--- a/frontend/src/i18n/KR/main.json
+++ b/frontend/src/i18n/KR/main.json
@@ -1,4 +1,8 @@
 {
   "back": "처음으로",
-  "title": "주문하기"
+  "title": "주문하기",
+  "cancel": "주문취소",
+  "order": "주문하기",
+  "totalCount": "총 주문수량",
+  "price": "결제금액"
 }

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -2,29 +2,39 @@ import styled from 'styled-components'
 import useTranslation from 'src/hooks/useTranslation'
 import Link from 'src/lib/router/Link'
 import LanguageButton from 'src/components/common/LanguageButton/LanguageButton'
+import Slider from 'src/components/common/Slider/Slider'
 
 const Home = () => {
   const t = useTranslation('home')
 
   return (
-    <Wrapper>
-      <LanguageWrapper>
-        <LanguageButton />
-      </LanguageWrapper>
+    <>
+      <Slider
+        imgList={[
+          'https://www.ediya.com/files/banner/IMG_1655429441772.jpg',
+          'https://www.ediya.com/files/banner/IMG_1650949894894.jpg',
+          'https://www.ediya.com/files/banner/IMG_1649291403353.jpg',
+        ]}
+      />
+      <Wrapper>
+        <LanguageWrapper>
+          <LanguageButton />
+        </LanguageWrapper>
 
-      <Title>{t('title')}</Title>
-      <Desc>{t('desc')}</Desc>
-      <ButtonWrapper>
-        <Button to="/main">
-          <ButtonTitle>{t('eatIn')}</ButtonTitle>
-          <ButtonDesc>{t('eatInCup')}</ButtonDesc>
-        </Button>
-        <Button to="/main">
-          <ButtonTitle>{t('takeOut')}</ButtonTitle>
-          <ButtonDesc>{t('takeOutCup')}</ButtonDesc>
-        </Button>
-      </ButtonWrapper>
-    </Wrapper>
+        <Title>{t('title')}</Title>
+        <Desc>{t('desc')}</Desc>
+        <ButtonWrapper>
+          <Button to="/main">
+            <ButtonTitle>{t('eatIn')}</ButtonTitle>
+            <ButtonDesc>{t('eatInCup')}</ButtonDesc>
+          </Button>
+          <Button to="/main">
+            <ButtonTitle>{t('takeOut')}</ButtonTitle>
+            <ButtonDesc>{t('takeOutCup')}</ButtonDesc>
+          </Button>
+        </ButtonWrapper>
+      </Wrapper>
+    </>
   )
 }
 

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -51,7 +51,7 @@ const LanguageWrapper = styled.div`
 `
 
 const Title = styled.h1`
-  margin-top: 256px;
+  margin-top: 100px;
   font-size: 72px;
   font-weight: 600;
   color: ${({ theme }) => theme.color.black};

--- a/frontend/src/pages/Main.tsx
+++ b/frontend/src/pages/Main.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import Header from 'src/components/common/Header/Header'
+import Cart from 'src/components/MainPage/Cart/Cart'
 import CategoryTabs from 'src/components/MainPage/CategoryTabs/CategoryTabs'
 import MenuList from 'src/components/MainPage/MenuList/MenuList'
 import styled from 'styled-components'
@@ -16,6 +17,7 @@ const Main = () => {
       <Header />
       <CategoryTabs selected={selectedCategoryId} onClickCategory={onClickCategory} />
       <MenuList selected={selectedCategoryId} />
+      <Cart />
     </Wrapper>
   )
 }
@@ -23,5 +25,7 @@ const Main = () => {
 export default Main
 
 const Wrapper = styled.div`
+  height: 100%;
+  position: relative;
   padding: 0 42px;
 `

--- a/frontend/src/styles/GlobalStyles.tsx
+++ b/frontend/src/styles/GlobalStyles.tsx
@@ -45,6 +45,10 @@ const GlobalStyle = createGlobalStyle`
     letter-spacing: -0.41px;
   }
 
+  #root {
+    height: 100%
+  }
+
 `
 
 export default GlobalStyle

--- a/frontend/src/types/api/category.ts
+++ b/frontend/src/types/api/category.ts
@@ -4,5 +4,4 @@ export interface CategoryType {
   id: number
   kr_name: string
   en_name: string
-  products: ProductType[]
 }

--- a/frontend/src/utils/priceUtil.ts
+++ b/frontend/src/utils/priceUtil.ts
@@ -1,0 +1,4 @@
+export const priceToString = (price: number | string) => {
+  if (typeof price === 'string') price = +price
+  return price.toLocaleString()
+}


### PR DESCRIPTION
## 📑 개요

상품 목록 서버 연동
장바구니 UI만 구현 

![화면 기록 2022-08-07 오후 3 22 47](https://user-images.githubusercontent.com/60956392/183278228-85e85a89-d9f1-4e37-b7fb-a587cdb6cfcf.gif)

<img width="498" alt="스크린샷 2022-08-07 오후 3 14 44" src="https://user-images.githubusercontent.com/60956392/183278233-7c70367a-5bde-4498-935e-7d4539002574.png">
<img width="499" alt="스크린샷 2022-08-07 오후 3 18 44" src="https://user-images.githubusercontent.com/60956392/183278234-41cedb3e-ae23-4cb0-aaf5-2813014c4240.png">


## 💬 작업 내용

상품 목록 서버 연동
장바구니 UI 구현
장바구니 전역 상태관리
포장 선택 화면 광고 Carousel 추가

cors 설정
카테고리별 상품 목록 불러오기 API 구현


브랜치를 나눴어야했는데.. 한 브랜치로 너무 많은 작업을 했네요.

### TODO : 
옵션 엔티티 구현 ( JSON으로 관리하려고 했는데, 관리하기 더 불편한 것 같아서, 그냥 테이블을 만들 계획입니다. )
옵션에 따라 장바구니 분기처리 필요 (서버 작업 후에 할 예정)


## 🕰 실제 소요 시간

5h

## 📎 관련 이슈

close #33
