### PR TITLE
Feat/43/option modal

### DIFF
--- a/frontend/src/Router.tsx
+++ b/frontend/src/Router.tsx
@@ -1,3 +1,4 @@
+import CartProvider from './contexts/CartContext'
 import Route from './lib/router/Route'
 import { Routes } from './lib/router/Routes'
 import Home from './pages/Home'
@@ -7,7 +8,9 @@ const Router = () => {
   return (
     <Routes>
       <Route path="/" component={<Home />} />
-      <Route path="/main" component={<Main />} />
+      <CartProvider>
+        <Route path="/main" component={<Main />} />
+      </CartProvider>
     </Routes>
   )
 }

--- a/frontend/src/components/MainPage/Cart/CartItem.tsx
+++ b/frontend/src/components/MainPage/Cart/CartItem.tsx
@@ -69,6 +69,6 @@ const Count = styled.p`
 
 const RemoveIcon = styled(Icon)`
   position: absolute;
-  top: -5px;
-  right: -8px;
+  top: 4px;
+  right: 4px;
 `

--- a/frontend/src/components/MainPage/Menu/Menu.tsx
+++ b/frontend/src/components/MainPage/Menu/Menu.tsx
@@ -1,18 +1,21 @@
-import { FC, useEffect, useState } from 'react'
+import { FC, useContext, useEffect, useState } from 'react'
 import { Image } from 'src/components/common/Image/Image'
 import OptionSelectModal from 'src/components/common/Modal/OptionSelectModal'
+import { InternationalizationContext } from 'src/contexts/InternationalizationContext'
 import { ProductOptionType } from 'src/types/api/product'
 import styled from 'styled-components'
 
 interface Props {
   id: number
   imgUrl: string
-  name: string
+  krName: string
+  enName: string
   price: number
   options: ProductOptionType[]
 }
 
-const Menu: FC<Props> = ({ id, imgUrl, name, price, options }) => {
+const Menu: FC<Props> = ({ id, imgUrl, krName, enName, price, options }) => {
+  const { language } = useContext(InternationalizationContext)
   const [open, setOpen] = useState(false)
 
   const onClose = () => {
@@ -27,7 +30,10 @@ const Menu: FC<Props> = ({ id, imgUrl, name, price, options }) => {
     <>
       <Wrapper onClick={onClickMenu}>
         <Image width={216} height={216} src={imgUrl} />
-        <MenuName>{name}</MenuName>
+        <MenuName>
+          {language === 'KR' && krName}
+          {language === 'EN' && enName}
+        </MenuName>
         <MenuPrice>{price}</MenuPrice>
       </Wrapper>
       <OptionSelectModal
@@ -35,7 +41,8 @@ const Menu: FC<Props> = ({ id, imgUrl, name, price, options }) => {
         onClose={onClose}
         id={id}
         imgUrl={imgUrl}
-        name={name}
+        krName={krName}
+        enName={enName}
         price={price}
         options={options}
       />

--- a/frontend/src/components/MainPage/Menu/Menu.tsx
+++ b/frontend/src/components/MainPage/Menu/Menu.tsx
@@ -1,5 +1,7 @@
-import { FC } from 'react'
+import { FC, useEffect, useState } from 'react'
 import { Image } from 'src/components/common/Image/Image'
+import OptionSelectModal from 'src/components/common/Modal/OptionSelectModal'
+import { ProductOptionType } from 'src/types/api/product'
 import styled from 'styled-components'
 
 interface Props {
@@ -7,16 +9,37 @@ interface Props {
   imgUrl: string
   name: string
   price: number
-  option: Record<string, any[]>
+  options: ProductOptionType[]
 }
 
-const Menu: FC<Props> = ({ imgUrl, name, price }) => {
+const Menu: FC<Props> = ({ id, imgUrl, name, price, options }) => {
+  const [open, setOpen] = useState(false)
+
+  const onClose = () => {
+    setOpen(false)
+  }
+
+  const onClickMenu = () => {
+    setOpen(true)
+  }
+
   return (
-    <Wrapper>
-      <Image width={216} height={216} src={imgUrl} />
-      <MenuName>{name}</MenuName>
-      <MenuPrice>{price}</MenuPrice>
-    </Wrapper>
+    <>
+      <Wrapper onClick={onClickMenu}>
+        <Image width={216} height={216} src={imgUrl} />
+        <MenuName>{name}</MenuName>
+        <MenuPrice>{price}</MenuPrice>
+      </Wrapper>
+      <OptionSelectModal
+        open={open}
+        onClose={onClose}
+        id={id}
+        imgUrl={imgUrl}
+        name={name}
+        price={price}
+        options={options}
+      />
+    </>
   )
 }
 

--- a/frontend/src/components/MainPage/MenuList/MenuList.tsx
+++ b/frontend/src/components/MainPage/MenuList/MenuList.tsx
@@ -26,7 +26,7 @@ const MenuList: FC<Props> = ({ selected }) => {
           name={language === 'KR' ? product.kr_name : language === 'EN' ? product.en_name : ''}
           price={product.price}
           imgUrl={product.thumbnail}
-          option={product.option}
+          options={product.options}
         />
       ))}
     </Wrapper>

--- a/frontend/src/components/MainPage/MenuList/MenuList.tsx
+++ b/frontend/src/components/MainPage/MenuList/MenuList.tsx
@@ -23,7 +23,8 @@ const MenuList: FC<Props> = ({ selected }) => {
         <Menu
           key={product.id}
           id={product.id}
-          name={language === 'KR' ? product.kr_name : language === 'EN' ? product.en_name : ''}
+          krName={product.kr_name}
+          enName={product.en_name}
           price={product.price}
           imgUrl={product.thumbnail}
           options={product.options}

--- a/frontend/src/components/common/Modal/Modal.tsx
+++ b/frontend/src/components/common/Modal/Modal.tsx
@@ -13,6 +13,7 @@ interface Props {
   hasSubmitButton?: boolean
   closeText?: string
   submitText?: string
+  backgroundLock?: boolean
 }
 
 const Modal: FC<Props> = ({
@@ -25,6 +26,7 @@ const Modal: FC<Props> = ({
   hasSubmitButton,
   closeText,
   submitText,
+  backgroundLock,
 }) => {
   const submitCallback = () => {
     onSubmit && onSubmit()
@@ -32,7 +34,7 @@ const Modal: FC<Props> = ({
   }
 
   return (
-    <ModalLayout open={open}>
+    <ModalLayout open={open} onClose={onClose} backgroundLock={backgroundLock}>
       <Wrapper>
         {title && <Title>{title}</Title>}
         <Content>{children}</Content>
@@ -42,7 +44,11 @@ const Modal: FC<Props> = ({
               {closeText || '취소'}
             </Button>
           )}
-          {hasSubmitButton && <Button width="full">{submitText || '확인'}</Button>}
+          {hasSubmitButton && (
+            <Button width="full" bgColor="red" onClick={submitCallback}>
+              {submitText || '확인'}
+            </Button>
+          )}
         </ButtonWrapper>
       </Wrapper>
     </ModalLayout>

--- a/frontend/src/components/common/Modal/Modal.tsx
+++ b/frontend/src/components/common/Modal/Modal.tsx
@@ -28,11 +28,6 @@ const Modal: FC<Props> = ({
   submitText,
   backgroundLock,
 }) => {
-  const submitCallback = () => {
-    onSubmit && onSubmit()
-    onClose && onClose()
-  }
-
   return (
     <ModalLayout open={open} onClose={onClose} backgroundLock={backgroundLock}>
       <Wrapper>
@@ -45,7 +40,7 @@ const Modal: FC<Props> = ({
             </Button>
           )}
           {hasSubmitButton && (
-            <Button width="full" bgColor="red" onClick={submitCallback}>
+            <Button width="full" bgColor="red" onClick={onSubmit}>
               {submitText || '확인'}
             </Button>
           )}

--- a/frontend/src/components/common/Modal/ModalLayout.tsx
+++ b/frontend/src/components/common/Modal/ModalLayout.tsx
@@ -5,14 +5,21 @@ import Portal from '../Portal/Portal'
 interface Props {
   open: boolean
   children?: React.ReactNode
-  onClose?: VoidFunction
+  onClose?: () => void
+  backgroundLock?: boolean
 }
 
-const ModalLayout: FC<Props> = ({ open, children, onClose }) => {
+const ModalLayout: FC<Props> = ({ open, children, onClose, backgroundLock = false }) => {
   const dimRef = useRef<HTMLDivElement>(null)
   const contentRef = useRef<HTMLDivElement>(null)
   // animation을 위한 state
   const [animationTrigger, setAnimationTrigger] = useState(open)
+
+  const onClickDimmer = () => {
+    if (!backgroundLock && onClose) {
+      onClose()
+    }
+  }
 
   useEffect(() => {
     if (open && !animationTrigger) setAnimationTrigger(true)
@@ -41,8 +48,8 @@ const ModalLayout: FC<Props> = ({ open, children, onClose }) => {
 
   return (
     <Portal>
-      <Wrapper open={open}>
-        <Dimmer ref={dimRef} open={open} onClick={onClose} />
+      <Wrapper>
+        <Dimmer ref={dimRef} open={open} onClick={onClickDimmer} />
         <Content ref={contentRef} open={open}>
           {children}
         </Content>
@@ -53,7 +60,7 @@ const ModalLayout: FC<Props> = ({ open, children, onClose }) => {
 
 export default ModalLayout
 
-const Wrapper = styled.div<{ open: boolean }>`
+const Wrapper = styled.div`
   position: fixed;
   top: 0;
   left: 0;

--- a/frontend/src/components/common/Modal/ModalLayout.tsx
+++ b/frontend/src/components/common/Modal/ModalLayout.tsx
@@ -111,12 +111,12 @@ const Dimmer = styled.div<{ open: boolean }>`
   left: 0;
   width: 100%;
   height: 100%;
-  background-color: rgba(0, 0, 0, 0.4);
+  background-color: rgba(0, 0, 0, 0.6);
   z-index: 1000;
 
   ${({ open }) =>
     css`
-      animation: ${open ? fadeIn : fadeOut} 0.3s forwards;
+      animation: ${open ? fadeIn : fadeOut} 0.4s forwards;
     `};
 `
 
@@ -125,6 +125,6 @@ const Content = styled.div<{ open: boolean }>`
 
   ${({ open }) =>
     css`
-      animation: ${open ? slideUp : fadeOut} 0.3s forwards;
+      animation: ${open ? slideUp : fadeOut} 0.4s forwards;
     `};
 `

--- a/frontend/src/components/common/Modal/OptionSelectModal.tsx
+++ b/frontend/src/components/common/Modal/OptionSelectModal.tsx
@@ -54,9 +54,19 @@ const OptionSelectModal: FC<Props> = ({ open, onClose, id, imgUrl, name, price, 
           <ProductName>{name}</ProductName>
           <ProductPrice>{priceToString(price)}</ProductPrice>
           <CountWrapper>
-            <Icon name="iconCircleMinus" size={36} onClick={onClickMinus} />
+            <Icon
+              name="iconCircleMinus"
+              size={36}
+              onClick={onClickMinus}
+              strokeColor={count === MIN_COUNT ? 'gray300' : 'black'}
+            />
             <span>{count}</span>
-            <Icon name="iconCirclePlus" size={36} onClick={onClickPlus} />
+            <Icon
+              name="iconCirclePlus"
+              size={36}
+              onClick={onClickPlus}
+              strokeColor={count === MAX_COUNT ? 'gray300' : 'black'}
+            />
           </CountWrapper>
         </LeftSection>
         <RightSection>

--- a/frontend/src/components/common/Modal/OptionSelectModal.tsx
+++ b/frontend/src/components/common/Modal/OptionSelectModal.tsx
@@ -1,4 +1,4 @@
-import { FC, useContext, useEffect, useState } from 'react'
+import React, { FC, useContext, useEffect, useState } from 'react'
 import { InternationalizationContext } from 'src/contexts/InternationalizationContext'
 import useTranslation from 'src/hooks/useTranslation'
 import { ProductOptionType } from 'src/types/api/product'
@@ -25,6 +25,7 @@ const OptionSelectModal: FC<Props> = ({ open, onClose, id, imgUrl, name, price, 
   const { language } = useContext(InternationalizationContext)
   const t = useTranslation('modal')
   const [count, setCount] = useState(1)
+  const [selectedOption, setSelectedOption] = useState<any>({})
 
   const onClickMinus = () => {
     if (count === MIN_COUNT) return
@@ -38,10 +39,22 @@ const OptionSelectModal: FC<Props> = ({ open, onClose, id, imgUrl, name, price, 
     setCount((prev) => prev + 1)
   }
 
+  const onChangeOptionDetail = (optionId: number, detailId: number) => {
+    setSelectedOption((prev: any) => ({
+      ...prev,
+      [optionId]: detailId,
+    }))
+  }
+
+  const closeCallback = () => {
+    onClose && onClose()
+    setSelectedOption({})
+  }
+
   return (
     <Modal
       open={open}
-      onClose={onClose}
+      onClose={closeCallback}
       title={t('optionTitle')}
       closeText={t('optionCancelText')}
       submitText={t('optionSubmitText')}
@@ -52,7 +65,7 @@ const OptionSelectModal: FC<Props> = ({ open, onClose, id, imgUrl, name, price, 
         <LeftSection>
           <Image src={imgUrl} width={224} height={224} />
           <ProductName>{name}</ProductName>
-          <ProductPrice>{priceToString(price)}</ProductPrice>
+          <ProductPrice>{priceToString(price * count)}</ProductPrice>
           <CountWrapper>
             <Icon
               name="iconCircleMinus"
@@ -78,10 +91,20 @@ const OptionSelectModal: FC<Props> = ({ open, onClose, id, imgUrl, name, price, 
               </OptionTitle>
               <OptionDetailList>
                 {option.option_details.map((detail) => (
-                  <OptionDetailButton key={detail.id}>
-                    {language === 'KR' && detail.kr_name}
-                    {language === 'EN' && detail.en_name}
-                  </OptionDetailButton>
+                  <React.Fragment key={detail.id}>
+                    <input
+                      type="radio"
+                      id={`radio-${detail.id}`}
+                      value={detail.id}
+                      checked={selectedOption[option.id] === detail.id}
+                      onChange={() => onChangeOptionDetail(option.id, detail.id)}
+                      hidden
+                    />
+                    <OptionDetailLabel htmlFor={`radio-${detail.id}`} key={detail.id}>
+                      {language === 'KR' && detail.kr_name}
+                      {language === 'EN' && detail.en_name}
+                    </OptionDetailLabel>
+                  </React.Fragment>
                 ))}
               </OptionDetailList>
             </div>
@@ -154,7 +177,7 @@ const OptionDetailList = styled.div`
   gap: 32px;
 `
 
-const OptionDetailButton = styled.button`
+const OptionDetailLabel = styled.label`
   padding-bottom: 14px;
   width: 80px;
   height: 80px;
@@ -168,4 +191,9 @@ const OptionDetailButton = styled.button`
 
   font-size: 20px;
   line-height: 140%;
+
+  input[type='radio']:checked + & {
+    border: 2px solid ${({ theme }) => theme.color.red};
+    color: ${({ theme }) => theme.color.red};
+  }
 `

--- a/frontend/src/components/common/Modal/OptionSelectModal.tsx
+++ b/frontend/src/components/common/Modal/OptionSelectModal.tsx
@@ -1,0 +1,161 @@
+import { FC, useContext, useEffect, useState } from 'react'
+import { InternationalizationContext } from 'src/contexts/InternationalizationContext'
+import useTranslation from 'src/hooks/useTranslation'
+import { ProductOptionType } from 'src/types/api/product'
+import { priceToString } from 'src/utils/priceUtil'
+import styled from 'styled-components'
+import Icon from '../Icon/Icon'
+import { Image } from '../Image/Image'
+import Modal from './Modal'
+
+interface Props {
+  open: boolean
+  onClose: () => void
+  id: number
+  imgUrl: string
+  name: string
+  price: number
+  options: ProductOptionType[]
+}
+
+const MIN_COUNT = 1
+const MAX_COUNT = 9
+
+const OptionSelectModal: FC<Props> = ({ open, onClose, id, imgUrl, name, price, options }) => {
+  const { language } = useContext(InternationalizationContext)
+  const t = useTranslation('modal')
+  const [count, setCount] = useState(1)
+
+  const onClickMinus = () => {
+    if (count === MIN_COUNT) return
+
+    setCount((prev) => prev - 1)
+  }
+
+  const onClickPlus = () => {
+    if (count === MAX_COUNT) return
+
+    setCount((prev) => prev + 1)
+  }
+
+  return (
+    <Modal
+      open={open}
+      onClose={onClose}
+      title={t('optionTitle')}
+      closeText={t('optionCancelText')}
+      submitText={t('optionSubmitText')}
+      hasCloseButton
+      hasSubmitButton
+    >
+      <Wrapper>
+        <LeftSection>
+          <Image src={imgUrl} width={224} height={224} />
+          <ProductName>{name}</ProductName>
+          <ProductPrice>{priceToString(price)}</ProductPrice>
+          <CountWrapper>
+            <Icon name="iconCircleMinus" size={36} onClick={onClickMinus} />
+            <span>{count}</span>
+            <Icon name="iconCirclePlus" size={36} onClick={onClickPlus} />
+          </CountWrapper>
+        </LeftSection>
+        <RightSection>
+          {options.map((option) => (
+            <div key={option.id}>
+              <OptionTitle>
+                {language === 'KR' && option.kr_name}
+                {language === 'EN' && option.en_name}
+              </OptionTitle>
+              <OptionDetailList>
+                {option.option_details.map((detail) => (
+                  <OptionDetailButton key={detail.id}>
+                    {language === 'KR' && detail.kr_name}
+                    {language === 'EN' && detail.en_name}
+                  </OptionDetailButton>
+                ))}
+              </OptionDetailList>
+            </div>
+          ))}
+        </RightSection>
+      </Wrapper>
+    </Modal>
+  )
+}
+
+export default OptionSelectModal
+
+const Wrapper = styled.div`
+  margin-top: 80px;
+  display: flex;
+
+  gap: 38px;
+`
+
+const LeftSection = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`
+
+const ProductName = styled.p`
+  margin-top: 14px;
+  font-weight: 600;
+  font-size: 32px;
+  line-height: 140%;
+  ${({ theme }) => theme.color.black}
+`
+
+const ProductPrice = styled.p`
+  margin-top: 8px;
+  font-size: 32px;
+  line-height: 140%;
+  ${({ theme }) => theme.color.black}
+`
+
+const CountWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 20px;
+
+  span {
+    width: 30px;
+    font-weight: 600;
+    font-size: 48px;
+    line-height: 57px;
+    text-align: center;
+  }
+`
+
+const RightSection = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 30px;
+`
+
+const OptionTitle = styled.p`
+  font-weight: 600;
+  font-size: 32px;
+  line-height: 140%;
+`
+
+const OptionDetailList = styled.div`
+  margin-top: 14px;
+  display: flex;
+  gap: 32px;
+`
+
+const OptionDetailButton = styled.button`
+  padding-bottom: 14px;
+  width: 80px;
+  height: 80px;
+
+  display: flex;
+  justify-content: center;
+  align-items: flex-end;
+
+  border: 1px solid ${({ theme }) => theme.color.black};
+  border-radius: 24px;
+
+  font-size: 20px;
+  line-height: 140%;
+`

--- a/frontend/src/components/common/Modal/OptionSelectModal.tsx
+++ b/frontend/src/components/common/Modal/OptionSelectModal.tsx
@@ -1,7 +1,7 @@
 import React, { FC, useContext, useEffect, useState } from 'react'
 import { InternationalizationContext } from 'src/contexts/InternationalizationContext'
 import useTranslation from 'src/hooks/useTranslation'
-import { ProductOptionType } from 'src/types/api/product'
+import { ProductOptionDetailType, ProductOptionType } from 'src/types/api/product'
 import { priceToString } from 'src/utils/priceUtil'
 import styled from 'styled-components'
 import Icon from '../Icon/Icon'
@@ -24,7 +24,8 @@ const MAX_COUNT = 9
 const OptionSelectModal: FC<Props> = ({ open, onClose, id, imgUrl, name, price, options }) => {
   const { language } = useContext(InternationalizationContext)
   const t = useTranslation('modal')
-  const [count, setCount] = useState(1)
+  const [count, setCount] = useState(MIN_COUNT)
+  const [extraPrice, setExtraPrice] = useState(0)
   const [selectedOption, setSelectedOption] = useState<any>({})
 
   const onClickMinus = () => {
@@ -39,16 +40,24 @@ const OptionSelectModal: FC<Props> = ({ open, onClose, id, imgUrl, name, price, 
     setCount((prev) => prev + 1)
   }
 
-  const onChangeOptionDetail = (optionId: number, detailId: number) => {
+  const onChangeOptionDetail = (optionId: number, detail: ProductOptionDetailType) => {
     setSelectedOption((prev: any) => ({
       ...prev,
-      [optionId]: detailId,
+      [optionId]: detail.id,
     }))
+
+    if (!detail.price) return
+
+    plusExtraPrice(detail.price)
   }
 
   const closeCallback = () => {
     onClose && onClose()
     setSelectedOption({})
+  }
+
+  const plusExtraPrice = (price: number) => {
+    setExtraPrice(price)
   }
 
   return (
@@ -65,7 +74,7 @@ const OptionSelectModal: FC<Props> = ({ open, onClose, id, imgUrl, name, price, 
         <LeftSection>
           <Image src={imgUrl} width={224} height={224} />
           <ProductName>{name}</ProductName>
-          <ProductPrice>{priceToString(price * count)}</ProductPrice>
+          <ProductPrice>{priceToString(price * count + extraPrice)}</ProductPrice>
           <CountWrapper>
             <Icon
               name="iconCircleMinus"
@@ -97,7 +106,7 @@ const OptionSelectModal: FC<Props> = ({ open, onClose, id, imgUrl, name, price, 
                       id={`radio-${detail.id}`}
                       value={detail.id}
                       checked={selectedOption[option.id] === detail.id}
-                      onChange={() => onChangeOptionDetail(option.id, detail.id)}
+                      onChange={() => onChangeOptionDetail(option.id, detail)}
                       hidden
                     />
                     <OptionDetailLabel htmlFor={`radio-${detail.id}`} key={detail.id}>
@@ -118,7 +127,7 @@ const OptionSelectModal: FC<Props> = ({ open, onClose, id, imgUrl, name, price, 
 export default OptionSelectModal
 
 const Wrapper = styled.div`
-  margin-top: 80px;
+  margin-top: 60px;
   display: flex;
 
   gap: 38px;
@@ -127,6 +136,7 @@ const Wrapper = styled.div`
 const LeftSection = styled.div`
   display: flex;
   flex-direction: column;
+  justify-content: center;
   align-items: center;
 `
 

--- a/frontend/src/components/common/Modal/OptionSelectModal.tsx
+++ b/frontend/src/components/common/Modal/OptionSelectModal.tsx
@@ -185,13 +185,12 @@ const Wrapper = styled.div`
   margin-top: 60px;
   display: flex;
 
-  gap: 38px;
+  gap: 60px;
 `
 
 const LeftSection = styled.div`
   display: flex;
   flex-direction: column;
-  justify-content: center;
   align-items: center;
 `
 

--- a/frontend/src/components/common/Modal/OptionSelectModal.tsx
+++ b/frontend/src/components/common/Modal/OptionSelectModal.tsx
@@ -1,4 +1,5 @@
 import React, { FC, useContext, useEffect, useState } from 'react'
+import { useCartAction } from 'src/contexts/CartContext'
 import { InternationalizationContext } from 'src/contexts/InternationalizationContext'
 import useTranslation from 'src/hooks/useTranslation'
 import { ProductOptionDetailType, ProductOptionType } from 'src/types/api/product'
@@ -13,7 +14,8 @@ interface Props {
   onClose: () => void
   id: number
   imgUrl: string
-  name: string
+  krName: string
+  enName: string
   price: number
   options: ProductOptionType[]
 }
@@ -21,8 +23,9 @@ interface Props {
 const MIN_COUNT = 1
 const MAX_COUNT = 9
 
-const OptionSelectModal: FC<Props> = ({ open, onClose, id, imgUrl, name, price, options }) => {
+const OptionSelectModal: FC<Props> = ({ open, onClose, id, imgUrl, krName, enName, price, options }) => {
   const { language } = useContext(InternationalizationContext)
+  const { add } = useCartAction()
   const t = useTranslation('modal')
   const [count, setCount] = useState(MIN_COUNT)
   const [extraPrice, setExtraPrice] = useState(0)
@@ -90,6 +93,15 @@ const OptionSelectModal: FC<Props> = ({ open, onClose, id, imgUrl, name, price, 
 
   const onSubmit = () => {
     if (!checkRequiredOptions()) return
+
+    add({
+      count,
+      id,
+      price,
+      kr_name: krName,
+      en_name: enName,
+      thumbnail: imgUrl,
+    })
     closeCallback()
   }
 
@@ -107,7 +119,10 @@ const OptionSelectModal: FC<Props> = ({ open, onClose, id, imgUrl, name, price, 
       <Wrapper>
         <LeftSection>
           <Image src={imgUrl} width={224} height={224} />
-          <ProductName>{name}</ProductName>
+          <ProductName>
+            {language === 'KR' && krName}
+            {language === 'EN' && enName}
+          </ProductName>
           <ProductPrice>{priceToString((price + extraPrice) * count)}</ProductPrice>
           <CountWrapper>
             <Icon

--- a/frontend/src/components/common/Modal/OptionSelectModal.tsx
+++ b/frontend/src/components/common/Modal/OptionSelectModal.tsx
@@ -64,10 +64,7 @@ const OptionSelectModal: FC<Props> = ({ open, onClose, id, imgUrl, krName, enNam
 
   const onClickOptionDetail = (optionId: number, detail: ProductOptionDetailType) => {
     if (selectedOption[optionId] === detail.id) {
-      setSelectedOption((prev) => ({
-        ...prev,
-        [optionId]: null,
-      }))
+      setSelectedOption(({ [optionId]: value, ...prev }) => prev)
 
       if (detail.price) {
         setExtraPrice(0)

--- a/frontend/src/components/common/Modal/OptionSelectModal.tsx
+++ b/frontend/src/components/common/Modal/OptionSelectModal.tsx
@@ -142,6 +142,7 @@ const OptionSelectModal: FC<Props> = ({ open, onClose, id, imgUrl, name, price, 
                       value={detail.id}
                       required={option.is_required}
                       checked={selectedOption[option.id] === detail.id}
+                      readOnly
                       hidden
                     />
                     <OptionDetailLabel
@@ -227,18 +228,17 @@ const OptionDetailList = styled.div`
 `
 
 const OptionDetailLabel = styled.label`
-  padding-bottom: 14px;
   width: 80px;
   height: 80px;
 
   display: flex;
   justify-content: center;
-  align-items: flex-end;
+  align-items: center;
 
   border: 1px solid ${({ theme }) => theme.color.black};
   border-radius: 24px;
 
-  font-size: 20px;
+  font-size: 24px;
   line-height: 140%;
 
   input[type='radio']:checked + & {

--- a/frontend/src/components/common/Modal/OptionSelectModal.tsx
+++ b/frontend/src/components/common/Modal/OptionSelectModal.tsx
@@ -74,7 +74,7 @@ const OptionSelectModal: FC<Props> = ({ open, onClose, id, imgUrl, name, price, 
         <LeftSection>
           <Image src={imgUrl} width={224} height={224} />
           <ProductName>{name}</ProductName>
-          <ProductPrice>{priceToString(price * count + extraPrice)}</ProductPrice>
+          <ProductPrice>{priceToString((price + extraPrice) * count)}</ProductPrice>
           <CountWrapper>
             <Icon
               name="iconCircleMinus"

--- a/frontend/src/contexts/CartContext.tsx
+++ b/frontend/src/contexts/CartContext.tsx
@@ -1,13 +1,25 @@
 import { createContext, FC, useContext, useMemo, useRef, useState } from 'react'
 import { ProductType } from 'src/types/api/product'
 
-export interface CartItemType extends ProductType {
-  cartId: number
+export interface CartItemType extends Omit<ProductType, 'options' | 'is_famous' | 'is_soldout'> {
+  cartId?: number
   count: number
 }
 
+interface CartActionType {
+  add: (cartItem: CartItemType) => void
+  remove: (id: number) => void
+  countUp(id: number): void
+  countDown(id: number): void
+}
+
 export const CartContext = createContext<CartItemType[]>([])
-export const CartActionContext = createContext<any>({})
+export const CartActionContext = createContext<CartActionType>({
+  add: () => {},
+  remove: () => {},
+  countUp: () => {},
+  countDown: () => {},
+})
 
 const MAX_COUNT = 10
 const MIN_COUNT = 1

--- a/frontend/src/i18n/EN/modal.json
+++ b/frontend/src/i18n/EN/modal.json
@@ -1,0 +1,5 @@
+{
+  "optionTitle": "Select Option",
+  "optionCancelText": "Cancel",
+  "optionSubmitText": "Order"
+}

--- a/frontend/src/i18n/KR/modal.json
+++ b/frontend/src/i18n/KR/modal.json
@@ -1,0 +1,5 @@
+{
+  "optionTitle": "옵션 선택",
+  "optionCancelText": "이전",
+  "optionSubmitText": "담기"
+}

--- a/frontend/src/styles/colors.ts
+++ b/frontend/src/styles/colors.ts
@@ -3,6 +3,7 @@ export const colors = {
   black: '#2f2f2f',
   gray800: '#3c3c3c',
   gray500: '#6a6a6a',
+  gray300: '#d1d1d1',
   gray100: '#f1f1f1',
   red: '#ea4a35',
   red100: '#f5897a',

--- a/frontend/src/types/api/product.ts
+++ b/frontend/src/types/api/product.ts
@@ -1,10 +1,24 @@
+export interface ProductOptionDetailType {
+  id: number
+  kr_name: string
+  en_name: string
+  price: number
+}
+export interface ProductOptionType {
+  id: number
+  kr_name: string
+  en_name: string
+  is_required: boolean
+  option_details: ProductOptionDetailType[]
+}
+
 export interface ProductType {
   id: number
   kr_name: string
   en_name: string
   price: number
   thumbnail: string
-  option: Record<string, any[]>
+  options: ProductOptionType[]
   is_famous: boolean
   is_soldout: boolean
 }


### PR DESCRIPTION
## 📑 개요

옵션 선택 모달 구현

## 💬 작업 내용

필수 옵션 선택 구현
추가 금액 옵션 로직 처리 
옵션 선택 해제 구현
장바구니 등록 완료

한 메뉴당 최소 1개 선택 , 최대 9개 선택 가능

<img width="369" alt="스크린샷 2022-08-09 오전 12 48 00" src="https://user-images.githubusercontent.com/60956392/183459078-5a3f4246-3b06-46c2-b3f3-1a224c09489d.png">
<img width="352" alt="스크린샷 2022-08-09 오전 12 47 53" src="https://user-images.githubusercontent.com/60956392/183459089-1d5d3e6b-7b89-4f08-b85d-e673ba715e92.png">

<img width="435" alt="스크린샷 2022-08-09 오전 12 45 29" src="https://user-images.githubusercontent.com/60956392/183458590-9b4f2f35-e193-4397-9a0d-25a3f112feee.png">


## 🕰 실제 소요 시간

5h

## 📎 관련 이슈

close #43


## 해결하지 못한 문제

기존 장바구니 아이템과 비교해서 카운트를 증가시키는 로직을 아직 구현하지 못했습니다.
PR이 너무 커지는 것 같아서 PR 날립니다.
