### PR TITLE
Feat/47/cart logic

### DIFF
--- a/frontend/src/components/MainPage/Cart/Cart.tsx
+++ b/frontend/src/components/MainPage/Cart/Cart.tsx
@@ -20,7 +20,7 @@ const Cart = () => {
     <Wrapper>
       <CartListWrapper>
         {cartList.map((cartItem) => (
-          <CartItem key={cartItem.id} cartItem={cartItem} />
+          <CartItem key={cartItem.cartId} cartItem={cartItem} />
         ))}
       </CartListWrapper>
       <CartListSummaryWrapper>

--- a/frontend/src/components/MainPage/Cart/CartItem.tsx
+++ b/frontend/src/components/MainPage/Cart/CartItem.tsx
@@ -2,7 +2,7 @@ import { FC, useContext } from 'react'
 import styled from 'styled-components'
 
 import { Image } from 'src/components/common/Image/Image'
-import { CartItemType, useCartAction } from 'src/contexts/CartContext'
+import { CartItemType, MAX_COUNT, MIN_COUNT, useCartAction } from 'src/contexts/CartContext'
 import { InternationalizationContext } from 'src/contexts/InternationalizationContext'
 import Icon from 'src/components/common/Icon/Icon'
 
@@ -12,23 +12,40 @@ interface Props {
 
 const CartItem: FC<Props> = ({ cartItem }) => {
   const { language } = useContext(InternationalizationContext)
-  const { remove } = useCartAction()
+  const { remove, countUp, countDown } = useCartAction()
 
-  const onClickXButton = (cartId: number) => {
-    remove(cartId)
+  const onClickXButton = () => {
+    remove(cartItem.cartId!)
   }
+
+  const onClickPlus = () => {
+    countUp(cartItem.cartId!)
+  }
+
+  const onClickMinus = () => {
+    countDown(cartItem.cartId!)
+  }
+
   return (
     <Wrapper>
-      <RemoveIcon name="iconCircleX" size={40} onClick={() => onClickXButton(cartItem.id)} />
+      <RemoveIcon name="iconCircleX" size={40} onClick={onClickXButton} />
       <Image src={cartItem.thumbnail} width={120} height={120} />
       <ProductName>
         {language === 'KR' && cartItem.kr_name}
         {language === 'EN' && cartItem.en_name}
       </ProductName>
       <CountWrapper>
-        <Icon name="iconCircleMinus" />
+        <Icon
+          name="iconCircleMinus"
+          onClick={onClickMinus}
+          strokeColor={cartItem.count === MIN_COUNT ? 'gray300' : 'black'}
+        />
         <Count>{cartItem.count}</Count>
-        <Icon name="iconCirclePlus" />
+        <Icon
+          name="iconCirclePlus"
+          onClick={onClickPlus}
+          strokeColor={cartItem.count === MAX_COUNT ? 'gray300' : 'black'}
+        />
       </CountWrapper>
     </Wrapper>
   )

--- a/frontend/src/components/MainPage/Cart/CartItem.tsx
+++ b/frontend/src/components/MainPage/Cart/CartItem.tsx
@@ -1,8 +1,8 @@
-import React, { FC, useContext } from 'react'
+import { FC, useContext } from 'react'
 import styled from 'styled-components'
 
 import { Image } from 'src/components/common/Image/Image'
-import { CartItemType } from 'src/contexts/CartContext'
+import { CartItemType, useCartAction } from 'src/contexts/CartContext'
 import { InternationalizationContext } from 'src/contexts/InternationalizationContext'
 import Icon from 'src/components/common/Icon/Icon'
 
@@ -12,9 +12,14 @@ interface Props {
 
 const CartItem: FC<Props> = ({ cartItem }) => {
   const { language } = useContext(InternationalizationContext)
+  const { remove } = useCartAction()
+
+  const onClickXButton = (cartId: number) => {
+    remove(cartId)
+  }
   return (
     <Wrapper>
-      <RemoveIcon name="iconCircleX" size={40} />
+      <RemoveIcon name="iconCircleX" size={40} onClick={() => onClickXButton(cartItem.id)} />
       <Image src={cartItem.thumbnail} width={120} height={120} />
       <ProductName>
         {language === 'KR' && cartItem.kr_name}

--- a/frontend/src/components/common/Modal/OptionSelectModal.tsx
+++ b/frontend/src/components/common/Modal/OptionSelectModal.tsx
@@ -1,5 +1,5 @@
 import React, { FC, useContext, useState } from 'react'
-import { useCartAction } from 'src/contexts/CartContext'
+import { SelectedOptionType, useCartAction } from 'src/contexts/CartContext'
 import { InternationalizationContext } from 'src/contexts/InternationalizationContext'
 import useCount from 'src/hooks/useCount'
 import useTranslation from 'src/hooks/useTranslation'
@@ -27,7 +27,7 @@ const OptionSelectModal: FC<Props> = ({ open, onClose, id, imgUrl, krName, enNam
   const t = useTranslation('modal')
   const { count, increaseCount, decreaseCount, isMaxCount, isMinCount } = useCount()
   const [extraPrice, setExtraPrice] = useState(0)
-  const [selectedOption, setSelectedOption] = useState<Record<string, number | string>>({})
+  const [selectedOption, setSelectedOption] = useState<SelectedOptionType>({})
 
   const requireOptionIdList: number[] = options.reduce((requiredIdList: number[], option) => {
     if (option.is_required) {
@@ -57,7 +57,7 @@ const OptionSelectModal: FC<Props> = ({ open, onClose, id, imgUrl, krName, enNam
   }
 
   const onClickOptionDetail = (optionId: number, detail: ProductOptionDetailType) => {
-    if (selectedOption[optionId] === detail.id) {
+    if (selectedOption[optionId]?.detailId === detail.id) {
       setSelectedOption(({ [optionId]: value, ...prev }) => prev)
 
       if (detail.price) {
@@ -69,7 +69,11 @@ const OptionSelectModal: FC<Props> = ({ open, onClose, id, imgUrl, krName, enNam
 
     setSelectedOption((prev) => ({
       ...prev,
-      [optionId]: detail.id,
+      [optionId]: {
+        detailId: detail.id,
+        detailKrName: detail.kr_name,
+        detailEnName: detail.en_name,
+      },
     }))
 
     if (!detail.price) return
@@ -92,6 +96,7 @@ const OptionSelectModal: FC<Props> = ({ open, onClose, id, imgUrl, krName, enNam
       kr_name: krName,
       en_name: enName,
       thumbnail: imgUrl,
+      selectedOptions: selectedOption,
     })
     closeCallback()
   }
@@ -147,7 +152,7 @@ const OptionSelectModal: FC<Props> = ({ open, onClose, id, imgUrl, krName, enNam
                       id={`radio-${detail.id}`}
                       value={detail.id}
                       required={option.is_required}
-                      checked={selectedOption[option.id] === detail.id}
+                      checked={selectedOption[option.id]?.detailId === detail.id}
                       readOnly
                       hidden
                     />

--- a/frontend/src/components/common/Modal/OptionSelectModal.tsx
+++ b/frontend/src/components/common/Modal/OptionSelectModal.tsx
@@ -29,7 +29,7 @@ const OptionSelectModal: FC<Props> = ({ open, onClose, id, imgUrl, krName, enNam
   const t = useTranslation('modal')
   const [count, setCount] = useState(MIN_COUNT)
   const [extraPrice, setExtraPrice] = useState(0)
-  const [selectedOption, setSelectedOption] = useState<Record<string, number>>({})
+  const [selectedOption, setSelectedOption] = useState<Record<string, number | string>>({})
 
   const requireOptionIdList: number[] = options.reduce((requiredIdList: number[], option) => {
     if (option.is_required) {

--- a/frontend/src/components/common/Modal/OptionSelectModal.tsx
+++ b/frontend/src/components/common/Modal/OptionSelectModal.tsx
@@ -1,6 +1,7 @@
-import React, { FC, useContext, useEffect, useState } from 'react'
+import React, { FC, useContext, useState } from 'react'
 import { useCartAction } from 'src/contexts/CartContext'
 import { InternationalizationContext } from 'src/contexts/InternationalizationContext'
+import useCount from 'src/hooks/useCount'
 import useTranslation from 'src/hooks/useTranslation'
 import { ProductOptionDetailType, ProductOptionType } from 'src/types/api/product'
 import { priceToString } from 'src/utils/priceUtil'
@@ -20,14 +21,11 @@ interface Props {
   options: ProductOptionType[]
 }
 
-const MIN_COUNT = 1
-const MAX_COUNT = 9
-
 const OptionSelectModal: FC<Props> = ({ open, onClose, id, imgUrl, krName, enName, price, options }) => {
   const { language } = useContext(InternationalizationContext)
   const { add } = useCartAction()
   const t = useTranslation('modal')
-  const [count, setCount] = useState(MIN_COUNT)
+  const { count, increaseCount, decreaseCount, isMaxCount, isMinCount } = useCount()
   const [extraPrice, setExtraPrice] = useState(0)
   const [selectedOption, setSelectedOption] = useState<Record<string, number | string>>({})
 
@@ -51,15 +49,11 @@ const OptionSelectModal: FC<Props> = ({ open, onClose, id, imgUrl, krName, enNam
   }
 
   const onClickMinus = () => {
-    if (count === MIN_COUNT) return
-
-    setCount((prev) => prev - 1)
+    decreaseCount()
   }
 
   const onClickPlus = () => {
-    if (count === MAX_COUNT) return
-
-    setCount((prev) => prev + 1)
+    increaseCount()
   }
 
   const onClickOptionDetail = (optionId: number, detail: ProductOptionDetailType) => {
@@ -126,14 +120,14 @@ const OptionSelectModal: FC<Props> = ({ open, onClose, id, imgUrl, krName, enNam
               name="iconCircleMinus"
               size={36}
               onClick={onClickMinus}
-              strokeColor={count === MIN_COUNT ? 'gray300' : 'black'}
+              strokeColor={isMinCount ? 'gray300' : 'black'}
             />
             <span>{count}</span>
             <Icon
               name="iconCirclePlus"
               size={36}
               onClick={onClickPlus}
-              strokeColor={count === MAX_COUNT ? 'gray300' : 'black'}
+              strokeColor={isMaxCount ? 'gray300' : 'black'}
             />
           </CountWrapper>
         </LeftSection>

--- a/frontend/src/components/common/Modal/OptionSelectModal.tsx
+++ b/frontend/src/components/common/Modal/OptionSelectModal.tsx
@@ -56,6 +56,26 @@ const OptionSelectModal: FC<Props> = ({ open, onClose, id, imgUrl, krName, enNam
     increaseCount()
   }
 
+  const onCloseModal = () => {
+    onClose && onClose()
+    setSelectedOption({})
+  }
+
+  const onSubmit = () => {
+    if (!checkRequiredOptions()) return
+
+    add({
+      count,
+      id,
+      price,
+      kr_name: krName,
+      en_name: enName,
+      thumbnail: imgUrl,
+      selectedOptions: selectedOption,
+    })
+    onCloseModal()
+  }
+
   const onClickOptionDetail = (optionId: number, detail: ProductOptionDetailType) => {
     if (selectedOption[optionId]?.detailId === detail.id) {
       setSelectedOption(({ [optionId]: value, ...prev }) => prev)
@@ -81,30 +101,10 @@ const OptionSelectModal: FC<Props> = ({ open, onClose, id, imgUrl, krName, enNam
     setExtraPrice(detail.price)
   }
 
-  const closeCallback = () => {
-    onClose && onClose()
-    setSelectedOption({})
-  }
-
-  const onSubmit = () => {
-    if (!checkRequiredOptions()) return
-
-    add({
-      count,
-      id,
-      price,
-      kr_name: krName,
-      en_name: enName,
-      thumbnail: imgUrl,
-      selectedOptions: selectedOption,
-    })
-    closeCallback()
-  }
-
   return (
     <Modal
       open={open}
-      onClose={closeCallback}
+      onClose={onCloseModal}
       onSubmit={onSubmit}
       title={t('optionTitle')}
       closeText={t('optionCancelText')}

--- a/frontend/src/contexts/CartContext.tsx
+++ b/frontend/src/contexts/CartContext.tsx
@@ -30,7 +30,7 @@ export const CartActionContext = createContext<CartActionType>({
   countDown: () => {},
 })
 
-const MAX_COUNT = 10
+const MAX_COUNT = 9
 const MIN_COUNT = 1
 
 interface Props {
@@ -44,25 +44,36 @@ const CartProvider: FC<Props> = ({ children }) => {
 
   const actions = useMemo(
     () => ({
-      // TODO : 옵션에 따른 아이템 분기처리
       add(cartItem: CartItemType) {
-        const cartId = idRef.current++
-        setCartList((prev) => [
-          ...prev,
-          {
-            ...cartItem,
-            cartId,
-          },
-        ])
+        setCartList((prev) => {
+          // 같은 상품, 같은 옵션 체크
+          const hasSameMenu = prev.findIndex(
+            (item) =>
+              item.id === cartItem.id && JSON.stringify(item.selectedOptions) === JSON.stringify(item.selectedOptions),
+          )
+
+          if (hasSameMenu !== -1) {
+            prev[hasSameMenu] = { ...prev[hasSameMenu], count: prev[hasSameMenu].count + cartItem.count }
+            return [...prev]
+          }
+
+          const cartId = idRef.current++
+          return [
+            ...prev,
+            {
+              ...cartItem,
+              cartId,
+            },
+          ]
+        })
       },
-      // TODO : 옵션에 따른 아이템 분기처리
-      remove(id: number) {
-        setCartList((prev) => prev.filter((item) => item.id !== id))
+      remove(cartId: number) {
+        setCartList((prev) => prev.filter((item) => item.cartId !== cartId))
       },
       countUp(id: number) {
         setCartList((prev) =>
           prev.map((item) =>
-            item.id === id && item.count < MAX_COUNT
+            item.id === id && item.count === MAX_COUNT
               ? {
                   ...item,
                   count: item.count + 1,
@@ -74,7 +85,7 @@ const CartProvider: FC<Props> = ({ children }) => {
       countDown(id: number) {
         setCartList((prev) =>
           prev.map((item) =>
-            item.id === id && item.count > MIN_COUNT
+            item.id === id && item.count === MIN_COUNT
               ? {
                   ...item,
                   count: item.count - 1,

--- a/frontend/src/contexts/CartContext.tsx
+++ b/frontend/src/contexts/CartContext.tsx
@@ -1,9 +1,18 @@
 import { createContext, FC, useContext, useMemo, useRef, useState } from 'react'
 import { ProductType } from 'src/types/api/product'
 
+interface SelectedDetailOptionType {
+  detailId: number
+  detailKrName: string
+  detailEnName: string
+}
+
+export type SelectedOptionType = Record<string, SelectedDetailOptionType>
+
 export interface CartItemType extends Omit<ProductType, 'options' | 'is_famous' | 'is_soldout'> {
   cartId?: number
   count: number
+  selectedOptions: SelectedOptionType
 }
 
 interface CartActionType {

--- a/frontend/src/contexts/CartContext.tsx
+++ b/frontend/src/contexts/CartContext.tsx
@@ -17,9 +17,9 @@ export interface CartItemType extends Omit<ProductType, 'options' | 'is_famous' 
 
 interface CartActionType {
   add: (cartItem: CartItemType) => void
-  remove: (id: number) => void
-  countUp(id: number): void
-  countDown(id: number): void
+  remove: (cartId: number) => void
+  countUp(cartId: number): void
+  countDown(cartId: number): void
 }
 
 export const CartContext = createContext<CartItemType[]>([])
@@ -30,8 +30,8 @@ export const CartActionContext = createContext<CartActionType>({
   countDown: () => {},
 })
 
-const MAX_COUNT = 9
-const MIN_COUNT = 1
+export const MAX_COUNT = 9
+export const MIN_COUNT = 1
 
 interface Props {
   children: React.ReactNode
@@ -70,22 +70,22 @@ const CartProvider: FC<Props> = ({ children }) => {
       remove(cartId: number) {
         setCartList((prev) => prev.filter((item) => item.cartId !== cartId))
       },
-      countUp(id: number) {
+      countUp(cartId: number) {
         setCartList((prev) =>
-          prev.map((item) =>
-            item.id === id && item.count === MAX_COUNT
+          prev.map((item) => {
+            return item.cartId === cartId && item.count !== MAX_COUNT
               ? {
                   ...item,
                   count: item.count + 1,
                 }
-              : item,
-          ),
+              : item
+          }),
         )
       },
-      countDown(id: number) {
+      countDown(cartId: number) {
         setCartList((prev) =>
           prev.map((item) =>
-            item.id === id && item.count === MIN_COUNT
+            item.cartId === cartId && item.count !== MIN_COUNT
               ? {
                   ...item,
                   count: item.count - 1,

--- a/frontend/src/contexts/CartContext.tsx
+++ b/frontend/src/contexts/CartContext.tsx
@@ -49,7 +49,8 @@ const CartProvider: FC<Props> = ({ children }) => {
           // 같은 상품, 같은 옵션 체크
           const hasSameMenu = prev.findIndex(
             (item) =>
-              item.id === cartItem.id && JSON.stringify(item.selectedOptions) === JSON.stringify(item.selectedOptions),
+              item.id === cartItem.id &&
+              JSON.stringify(item.selectedOptions) === JSON.stringify(cartItem.selectedOptions),
           )
 
           if (hasSameMenu !== -1) {

--- a/frontend/src/hooks/useCount.ts
+++ b/frontend/src/hooks/useCount.ts
@@ -1,0 +1,26 @@
+import { useState } from 'react'
+
+export const MIN_COUNT = 1
+export const MAX_COUNT = 9
+
+const useCount = () => {
+  const [count, setCount] = useState(MIN_COUNT)
+  const isMinCount = count === MIN_COUNT
+  const isMaxCount = count === MAX_COUNT
+
+  const decreaseCount = () => {
+    if (count === MIN_COUNT) return
+
+    setCount((prev) => prev - 1)
+  }
+
+  const increaseCount = () => {
+    if (count === MAX_COUNT) return
+
+    setCount((prev) => prev + 1)
+  }
+
+  return { count, increaseCount, decreaseCount, isMaxCount, isMinCount }
+}
+
+export default useCount


### PR DESCRIPTION
## 📑 개요

장바구니 로직 구현

## 💬 작업 내용

 같은 상품이어도 옵션이 다르면 장바구니에 다르게 들어간다.
 같은 상품, 같은 옵션이면 개수(카운트)가 증가한다.
 장바구니에서 상품의 개수를 늘릴 수 있다.
 장바구니에서 상품을 삭제할 수 있다.

## 🕰 실제 소요 시간

1h 30m

## 📎 관련 이슈

close #47

## 추가 구현 사항

장바구니에서 9개인 상품은 주문 추가 안되도록 막기 OR 개수제한 풀기 OR 개수제한을 많이 늘리기. 고민중입니다.
스타벅스, 투썸 어플, 키오스크를 조사해보고 어떻게 처리하는지 참고해야 할 것 같습니다. 
(스타벅스 어플에선 한 주문당 한 메뉴 9개 LIMIT)

뒤로가기 OR 주문 취소 시, 장바구니 전역상태 비우기