### PR TITLE
Feat/62/nest static setting

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -13,6 +13,7 @@
         "@nestjs/config": "^2.2.0",
         "@nestjs/core": "^9.0.0",
         "@nestjs/platform-express": "^9.0.0",
+        "@nestjs/serve-static": "^3.0.0",
         "@nestjs/typeorm": "^9.0.0",
         "mysql2": "^2.3.3",
         "reflect-metadata": "^0.1.13",
@@ -1673,6 +1674,23 @@
       "peerDependencies": {
         "typescript": "^4.3.5"
       }
+    },
+    "node_modules/@nestjs/serve-static": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/serve-static/-/serve-static-3.0.0.tgz",
+      "integrity": "sha512-TpXjgs4136dQqWUjEcONqppqXDsrJhRkmKWzuBMOUAnP4HjHpNmlycvkHnDnWSoG2YD4a7Enh4ViYGWqCfHStA==",
+      "dependencies": {
+        "path-to-regexp": "0.2.5"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^9.0.0",
+        "@nestjs/core": "^9.0.0"
+      }
+    },
+    "node_modules/@nestjs/serve-static/node_modules/path-to-regexp": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.2.5.tgz",
+      "integrity": "sha512-l6qtdDPIkmAmzEO6egquYDfqQGPMRNGjYtrU13HAXb3YSRrt7HSb1sJY0pKp6o2bAa86tSB6iwaW2JbthPKr7Q=="
     },
     "node_modules/@nestjs/testing": {
       "version": "9.0.7",
@@ -10087,6 +10105,21 @@
         "fs-extra": "10.1.0",
         "jsonc-parser": "3.0.0",
         "pluralize": "8.0.0"
+      }
+    },
+    "@nestjs/serve-static": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/serve-static/-/serve-static-3.0.0.tgz",
+      "integrity": "sha512-TpXjgs4136dQqWUjEcONqppqXDsrJhRkmKWzuBMOUAnP4HjHpNmlycvkHnDnWSoG2YD4a7Enh4ViYGWqCfHStA==",
+      "requires": {
+        "path-to-regexp": "0.2.5"
+      },
+      "dependencies": {
+        "path-to-regexp": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.2.5.tgz",
+          "integrity": "sha512-l6qtdDPIkmAmzEO6egquYDfqQGPMRNGjYtrU13HAXb3YSRrt7HSb1sJY0pKp6o2bAa86tSB6iwaW2JbthPKr7Q=="
+        }
       }
     },
     "@nestjs/testing": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -9,7 +9,7 @@
     "prebuild": "rimraf dist",
     "build": "nest build",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
-    "start": "nest start",
+    "start": "cd .. && cd frontend && npm run build && cd .. && cd backend && nest start",
     "start:dev": "nest start --watch",
     "start:debug": "nest start --debug --watch",
     "start:prod": "node dist/main",

--- a/backend/package.json
+++ b/backend/package.json
@@ -9,7 +9,7 @@
     "prebuild": "rimraf dist",
     "build": "nest build",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
-    "start": "cd .. && cd frontend && npm run build && cd .. && cd backend && nest start",
+    "start": "cd ../frontend && npm run build && cd ../backend && nest start",
     "start:dev": "nest start --watch",
     "start:debug": "nest start --debug --watch",
     "start:prod": "node dist/main",

--- a/backend/package.json
+++ b/backend/package.json
@@ -25,6 +25,7 @@
     "@nestjs/config": "^2.2.0",
     "@nestjs/core": "^9.0.0",
     "@nestjs/platform-express": "^9.0.0",
+    "@nestjs/serve-static": "^3.0.0",
     "@nestjs/typeorm": "^9.0.0",
     "mysql2": "^2.3.3",
     "reflect-metadata": "^0.1.13",

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,15 +1,21 @@
 import { Module } from '@nestjs/common'
+import { ServeStaticModule } from '@nestjs/serve-static'
 import { ConfigModule } from '@nestjs/config'
 import { TypeOrmModule } from '@nestjs/typeorm'
 import { CategoriesModule } from './categories/categories.module'
 import { ProductsModule } from './products/products.module'
 import { OrdersModule } from './orders/orders.module'
 import { OrderToProductModule } from './order-to-product/order-to-product.module'
+import { join } from 'path'
 
 @Module({
   imports: [
     ConfigModule.forRoot({
       isGlobal: true,
+    }),
+    ServeStaticModule.forRoot({
+      rootPath: join(process.cwd(), '..', 'frontend', 'build'),
+      exclude: ['/api*'],
     }),
     TypeOrmModule.forRoot({
       type: 'mysql',


### PR DESCRIPTION
## 📑 개요

배포 준비

## 💬 작업 내용

`nest/serve-static` 라이브러리를 통해 정적 사이트 배포

처음에는 경로를 `join(__dirname, '../../frontend/build'),` 이렇게 지정해줬다가,

`../../` 이 마음에 안들어서 찾던 와중에 상림님이 쓰신 `process.cwd()` 를 가져왔습니다. 감사합니다~

`/api` url 예외처리 

backend `start` 스크립트 수정

무지성으로 진짜 단순하게 처리했습니다 😅
리액트 빌드하고 네스트 실행합니다.

`"start": "cd ../frontend && npm run build && cd ../backend && nest start",`


## 🕰 실제 소요 시간

15m

## 📎 관련 이슈

close #62
