### PR TITLE
Feat/59/receipt modal

### DIFF
--- a/backend/src/products/entities/products.entity.ts
+++ b/backend/src/products/entities/products.entity.ts
@@ -40,6 +40,9 @@ export class Product extends BaseEntity {
   })
   is_soldout: boolean
 
+  @Column({ default: '' })
+  option: string
+
   @Column()
   category_id: number
 

--- a/frontend/src/api/order/order.ts
+++ b/frontend/src/api/order/order.ts
@@ -1,0 +1,19 @@
+import axios from 'axios'
+
+import { OrderMenuType, OrderReceiptType } from 'src/types/api/order'
+
+export const orderMenu = async ({
+  paymentMethod,
+  paidAmount,
+  totalAmount,
+  products,
+}: OrderMenuType): Promise<OrderReceiptType> => {
+  const { data } = await axios.post('/orders', {
+    payment_method: paymentMethod,
+    paid_amount: paidAmount,
+    total_amount: totalAmount,
+    products,
+  })
+
+  return data
+}

--- a/frontend/src/components/common/Loader/PaymentLoader.tsx
+++ b/frontend/src/components/common/Loader/PaymentLoader.tsx
@@ -1,23 +1,56 @@
+import { FC, useEffect } from 'react'
 import styled, { keyframes } from 'styled-components'
 
+import useModal from 'src/hooks/useModal'
+
+import ReceiptModal from '../Modal/ReceiptModal/ReceiptModal'
 import Portal from '../Portal/Portal'
 
+interface Props {
+  open: boolean
+  onClose?: () => void
+}
+
 // reference: https://codepen.io/search/pens?q=coffee+loading
-const Loader = () => {
+const PaymentLoader: FC<Props> = ({ open, onClose }) => {
+  const { open: openReceipt, onOpen: onOpenReceipt, onClose: onCloseReceipt } = useModal()
+
+  useEffect(() => {
+    const randDelay = Math.floor(Math.random() * 4) + 3 * 1000
+    if (open) {
+      setTimeout(() => {
+        onOpenReceipt()
+      }, randDelay)
+    }
+  }, [open])
+
+  if (!open) return null
+
   return (
-    <Portal>
-      <Wrapper>
-        <Dimmer />
-        <CoffeeWrapper>
-          <Coffee />
-          <Text>Loading</Text>
-        </CoffeeWrapper>
-      </Wrapper>
-    </Portal>
+    <>
+      <Portal>
+        <Wrapper>
+          <Dimmer />
+          <CoffeeWrapper>
+            <Coffee />
+            <Text>Loading</Text>
+          </CoffeeWrapper>
+        </Wrapper>
+      </Portal>
+      <ReceiptModal
+        open={openReceipt}
+        onClose={onCloseReceipt}
+        orderNumber={0}
+        paymentMethod={''}
+        paidAmount={0}
+        totalAmount={0}
+        changes={0}
+      />
+    </>
   )
 }
 
-export default Loader
+export default PaymentLoader
 
 const Wrapper = styled.div`
   position: fixed;

--- a/frontend/src/components/common/Modal/CardInputModal.tsx
+++ b/frontend/src/components/common/Modal/CardInputModal.tsx
@@ -1,9 +1,14 @@
-import { FC } from 'react'
+import { FC, useEffect } from 'react'
 import styled from 'styled-components'
+
+import useModal from 'src/hooks/useModal'
 
 import Modal from './Modal'
 
 import { Image } from '../Image/Image'
+import PaymentLoader from '../Loader/PaymentLoader'
+
+const CARD_DELAY = 2000
 
 interface Props {
   open: boolean
@@ -11,12 +16,26 @@ interface Props {
 }
 
 const CardInputModal: FC<Props> = ({ open, onClose }) => {
+  const { open: openLoader, onOpen: onOpenLoader, onClose: onCloseLoader } = useModal()
+
+  useEffect(() => {
+    if (!open) return
+
+    setTimeout(() => {
+      onOpenLoader()
+      onClose()
+    }, CARD_DELAY)
+  }, [open])
+
   return (
-    <Modal open={open} onClose={onClose} title="카드를 넣어주세요" hasCloseButton>
-      <ImageWrapper>
-        <Image name="imagePosMachine" width={526} height={526} />
-      </ImageWrapper>
-    </Modal>
+    <>
+      <Modal open={open} onClose={onClose} title="카드를 넣어주세요" hasCloseButton>
+        <ImageWrapper>
+          <Image name="imagePosMachine" width={526} height={526} />
+        </ImageWrapper>
+      </Modal>
+      <PaymentLoader open={openLoader} onClose={onCloseLoader} paymentMethod="credit_card" />
+    </>
   )
 }
 

--- a/frontend/src/components/common/Modal/CashInputModal.tsx
+++ b/frontend/src/components/common/Modal/CashInputModal.tsx
@@ -31,7 +31,6 @@ const CashInputModal: FC<Props> = ({ open, onClose }) => {
   }
 
   const onSubmit = () => {
-    // TODO : 주문 API + 영수증 모달
     onClose()
     onOpenLoader()
   }
@@ -68,7 +67,7 @@ const CashInputModal: FC<Props> = ({ open, onClose }) => {
           </ButtonWrapper>
         </Wrapper>
       </Modal>
-      <PaymentLoader open={openLoader} onClose={onCloseLoader} />
+      <PaymentLoader open={openLoader} onClose={onCloseLoader} paymentMethod="cash" paidAmount={cash} />
     </>
   )
 }

--- a/frontend/src/components/common/Modal/CashInputModal.tsx
+++ b/frontend/src/components/common/Modal/CashInputModal.tsx
@@ -2,10 +2,13 @@ import { FC, useState } from 'react'
 import styled from 'styled-components'
 
 import { useCartSummary } from 'src/contexts/CartContext'
+import useModal from 'src/hooks/useModal'
 import useTranslation from 'src/hooks/useTranslation'
 import { priceToString } from 'src/utils/priceUtil'
 
 import Modal from './Modal'
+
+import PaymentLoader from '../Loader/PaymentLoader'
 
 const CASH_LIST: number[] = [500, 1000, 5000, 10000]
 
@@ -18,6 +21,7 @@ const CashInputModal: FC<Props> = ({ open, onClose }) => {
   const t = useTranslation('modal')
   const { price } = useCartSummary()
   const [cash, setCash] = useState(0)
+  const { open: openLoader, onOpen: onOpenLoader, onClose: onCloseLoader } = useModal()
 
   const onClickCashButton = (inputCash: number) => {
     // TODO : Alert
@@ -28,39 +32,44 @@ const CashInputModal: FC<Props> = ({ open, onClose }) => {
 
   const onSubmit = () => {
     // TODO : 주문 API + 영수증 모달
+    onClose()
+    onOpenLoader()
   }
 
   return (
-    <Modal
-      open={open}
-      onClose={onClose}
-      onSubmit={onSubmit}
-      title={t('inputCashTitle')}
-      closeText={t('inputCashCancelText')}
-      submitText={t('inputCashSubmitText')}
-      hasCloseButton
-      hasSubmitButton
-    >
-      <Wrapper>
-        <PriceWrapper>
-          <PriceRow>
-            <p>{t('totalPrice')} : </p>
-            <p className="price">{priceToString(price)}</p>
-          </PriceRow>
-          <PriceRow>
-            <p>{t('inputCash')} : </p>
-            <p className="price">{priceToString(cash)}</p>
-          </PriceRow>
-        </PriceWrapper>
-        <ButtonWrapper>
-          {CASH_LIST.map((cash) => (
-            <CashButton key={cash} onClick={() => onClickCashButton(cash)}>
-              {priceToString(cash)}
-            </CashButton>
-          ))}
-        </ButtonWrapper>
-      </Wrapper>
-    </Modal>
+    <>
+      <Modal
+        open={open}
+        onClose={onClose}
+        onSubmit={onSubmit}
+        title={t('inputCashTitle')}
+        closeText={t('inputCashCancelText')}
+        submitText={t('inputCashSubmitText')}
+        hasCloseButton
+        hasSubmitButton
+      >
+        <Wrapper>
+          <PriceWrapper>
+            <PriceRow>
+              <p>{t('totalPrice')} : </p>
+              <p className="price">{priceToString(price)}</p>
+            </PriceRow>
+            <PriceRow>
+              <p>{t('inputCash')} : </p>
+              <p className="price">{priceToString(cash)}</p>
+            </PriceRow>
+          </PriceWrapper>
+          <ButtonWrapper>
+            {CASH_LIST.map((cash) => (
+              <CashButton key={cash} onClick={() => onClickCashButton(cash)}>
+                {priceToString(cash)}
+              </CashButton>
+            ))}
+          </ButtonWrapper>
+        </Wrapper>
+      </Modal>
+      <PaymentLoader open={openLoader} onClose={onCloseLoader} />
+    </>
   )
 }
 

--- a/frontend/src/components/common/Modal/OptionSelectModal.tsx
+++ b/frontend/src/components/common/Modal/OptionSelectModal.tsx
@@ -30,7 +30,7 @@ const OptionSelectModal: FC<Props> = ({ open, onClose, id, imgUrl, krName, enNam
   const { language } = useContext(InternationalizationContext)
   const { add } = useCartAction()
   const t = useTranslation('modal')
-  const { count, increaseCount, decreaseCount, isMaxCount, isMinCount } = useCount()
+  const { count, increaseCount, decreaseCount, initCount, isMaxCount, isMinCount } = useCount()
   const [extraPrice, setExtraPrice] = useState<ExtraPriceType>({})
   const [selectedOption, setSelectedOption] = useState<SelectedOptionType>({})
 
@@ -66,6 +66,7 @@ const OptionSelectModal: FC<Props> = ({ open, onClose, id, imgUrl, krName, enNam
   const onCloseModal = () => {
     onClose && onClose()
     setSelectedOption({})
+    initCount()
   }
 
   const onSubmit = () => {

--- a/frontend/src/components/common/Modal/ReceiptModal/ReceiptModal.tsx
+++ b/frontend/src/components/common/Modal/ReceiptModal/ReceiptModal.tsx
@@ -1,0 +1,175 @@
+import React, { FC, useContext } from 'react'
+import styled from 'styled-components'
+
+import { useCartAction, useCartList } from 'src/contexts/CartContext'
+import { InternationalizationContext } from 'src/contexts/InternationalizationContext'
+import useTranslation from 'src/hooks/useTranslation'
+import { useRouter } from 'src/lib/router/Routes'
+import { priceToString } from 'src/utils/priceUtil'
+
+import Modal from '../Modal'
+
+interface Props {
+  open: boolean
+  onClose: () => void
+  orderNumber: number
+  paymentMethod: string
+  paidAmount: number
+  totalAmount: number
+  changes: number
+}
+
+const ReceiptModal: FC<Props> = ({ open, onClose, orderNumber, paymentMethod, paidAmount, totalAmount, changes }) => {
+  const { language } = useContext(InternationalizationContext)
+  const t = useTranslation('modal')
+  const router = useRouter()
+  const cartList = useCartList()
+  const { clear } = useCartAction()
+
+  const onSubmit = () => {
+    onClose()
+    clear()
+    router('/')
+  }
+
+  return (
+    <Modal
+      open={open}
+      onSubmit={onSubmit}
+      title={t('receiptTitle')}
+      submitText={t('receiptSubmitText')}
+      hasSubmitButton
+    >
+      <div>
+        <OrderNumber>
+          {t('orderNumber')} : {orderNumber}
+        </OrderNumber>
+        <OrderListWrapper>
+          {cartList.map((cartItem) => (
+            <React.Fragment key={cartItem.cartId}>
+              <OrderItemWrapper>
+                <OrderItemName>
+                  {language === 'KR' && cartItem.kr_name}
+                  {language === 'EN' && cartItem.en_name}
+                </OrderItemName>
+                <OrderItemCount>{cartItem.count}</OrderItemCount>
+                <Price>{priceToString(cartItem.price * cartItem.count)}</Price>
+              </OrderItemWrapper>
+              <OrderItemOptionWrapper>
+                {Object.values(cartItem.selectedOptions).map((option, idx) => (
+                  <p key={option.detailId}>
+                    {language === 'KR' && option.detailKrName}
+                    {language === 'EN' && option.detailEnName}
+                    <em className="delimiter">{idx !== Object.values(cartItem.selectedOptions).length - 1 && '/'}</em>
+                  </p>
+                ))}
+              </OrderItemOptionWrapper>
+            </React.Fragment>
+          ))}
+        </OrderListWrapper>
+        <PaymentMethod>
+          {t('paymentMethod')} : {paymentMethod}
+        </PaymentMethod>
+        <PriceSummaryWrapper>
+          <PriceSummaryRow>
+            <p>{t('inputCash')}</p>
+            <p>{paidAmount}</p>
+          </PriceSummaryRow>
+          <PriceSummaryRow>
+            <p>{t('totalPrice')}</p>
+            <p>{totalAmount}</p>
+          </PriceSummaryRow>
+          <PriceSummaryRow>
+            <p>{t('changes')}</p>
+            <p>{changes}</p>
+          </PriceSummaryRow>
+        </PriceSummaryWrapper>
+      </div>
+    </Modal>
+  )
+}
+
+export default ReceiptModal
+
+const OrderNumber = styled.p`
+  margin-top: 36px;
+
+  font-weight: 600;
+  font-size: 36px;
+  line-height: 43px;
+  text-align: center;
+
+  color: ${({ theme }) => theme.color.black};
+`
+
+const OrderListWrapper = styled.div`
+  margin-top: 80px;
+  height: 300px;
+  overflow-y: auto;
+`
+
+const OrderItemWrapper = styled.div`
+  display: flex;
+  align-items: center;
+
+  font-weight: 600;
+  font-size: 32px;
+  line-height: 38px;
+`
+
+const OrderItemOptionWrapper = styled.div`
+  margin-top: 8px;
+  margin-bottom: 16px;
+
+  display: flex;
+
+  font-size: 24px;
+  line-height: 28px;
+
+  color: ${({ theme }) => theme.color.gray500};
+
+  .delimiter {
+    margin-left: 4px;
+    margin-right: 4px;
+  }
+`
+
+const OrderItemName = styled.p`
+  width: 300px;
+`
+
+const OrderItemCount = styled.p`
+  width: 42px;
+  height: 38px;
+
+  text-align: center;
+`
+
+const Price = styled.p`
+  width: 149px;
+  margin-right: 16px;
+  text-align: end;
+`
+
+const PaymentMethod = styled.p`
+  font-weight: 600;
+  font-size: 28px;
+  line-height: 33px;
+  color: ${({ theme }) => theme.color.black};
+`
+
+const PriceSummaryWrapper = styled.div`
+  margin-top: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+`
+
+const PriceSummaryRow = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+
+  font-size: 24px;
+  line-height: 29px;
+`

--- a/frontend/src/hooks/useCount.ts
+++ b/frontend/src/hooks/useCount.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useCallback, useState } from 'react'
 
 export const MIN_COUNT = 1
 export const MAX_COUNT = 9
@@ -8,19 +8,23 @@ const useCount = () => {
   const isMinCount = count === MIN_COUNT
   const isMaxCount = count === MAX_COUNT
 
-  const decreaseCount = () => {
+  const decreaseCount = useCallback(() => {
     if (count === MIN_COUNT) return
 
     setCount((prev) => prev - 1)
-  }
+  }, [count])
 
-  const increaseCount = () => {
+  const increaseCount = useCallback(() => {
     if (count === MAX_COUNT) return
 
     setCount((prev) => prev + 1)
-  }
+  }, [count])
 
-  return { count, increaseCount, decreaseCount, isMaxCount, isMinCount }
+  const initCount = useCallback(() => {
+    setCount(MIN_COUNT)
+  }, [])
+
+  return { count, increaseCount, decreaseCount, initCount, isMaxCount, isMinCount }
 }
 
 export default useCount

--- a/frontend/src/i18n/EN/modal.json
+++ b/frontend/src/i18n/EN/modal.json
@@ -18,7 +18,7 @@
   "orderNumber": "Order No.",
   "paymentMethod": "Payment Method",
   "changes": "Changes",
-  "receiptCloseAnnounce1": "This screen automatically disappears after",
+  "receiptCloseAnnounce1": "This screen disappears after ",
   "receiptCloseAnnounce2": "seconds",
   "receiptSubmitText": "OK"
 }

--- a/frontend/src/i18n/EN/modal.json
+++ b/frontend/src/i18n/EN/modal.json
@@ -13,5 +13,12 @@
   "inputCashTitle": "Input Cash",
   "inputCash": "Cash",
   "inputCashCancelText": "Cancel",
-  "inputCashSubmitText": "Order"
+  "inputCashSubmitText": "Order",
+  "receiptTitle": "Complete Order",
+  "orderNumber": "Order No.",
+  "paymentMethod": "Payment Method",
+  "changes": "Changes",
+  "receiptCloseAnnounce1": "This screen automatically disappears after",
+  "receiptCloseAnnounce2": "seconds",
+  "receiptSubmitText": "OK"
 }

--- a/frontend/src/i18n/KR/modal.json
+++ b/frontend/src/i18n/KR/modal.json
@@ -18,7 +18,7 @@
   "orderNumber": "주문 번호",
   "paymentMethod": "결제방식",
   "changes": "잔돈",
-  "receiptCloseAnnounce1": "주의 :이 화면은",
+  "receiptCloseAnnounce1": "주의 : 이 화면은",
   "receiptCloseAnnounce2": "초 뒤에 자동으로 사라집니다",
   "receiptSubmitText": "확인"
 }

--- a/frontend/src/i18n/KR/modal.json
+++ b/frontend/src/i18n/KR/modal.json
@@ -13,5 +13,12 @@
   "inputCashTitle": "현금을 투입해주세요",
   "inputCash": "투입 금액",
   "inputCashCancelText": "취소",
-  "inputCashSubmitText": "결제하기"
+  "inputCashSubmitText": "결제하기",
+  "receiptTitle": "주문이 완료되었습니다",
+  "orderNumber": "주문 번호",
+  "paymentMethod": "결제방식",
+  "changes": "잔돈",
+  "receiptCloseAnnounce1": "주의 :이 화면은",
+  "receiptCloseAnnounce2": "초 뒤에 자동으로 사라집니다",
+  "receiptSubmitText": "확인"
 }

--- a/frontend/src/types/api/order.ts
+++ b/frontend/src/types/api/order.ts
@@ -1,0 +1,20 @@
+export type PaymentMethodType = 'cash' | 'credit_card'
+
+export interface OrdersProductType {
+  product_id: number
+  count: number
+}
+
+export interface OrderMenuType {
+  paymentMethod: PaymentMethodType
+  paidAmount: number
+  totalAmount: number
+  products: OrdersProductType[]
+}
+
+export interface OrderReceiptType {
+  payment_method: PaymentMethodType
+  paid_amount: number
+  total_amount: number
+  order_number: number
+}


### PR DESCRIPTION
## 📑 개요

영수증 모달 구현

## 💬 작업 내용

주문하기 구현 (서버 연동)

주문 -> 로딩 -> 영수증 

영수증 모달 구현 

영수증 10초 뒤 꺼지기, 확인버튼 누르면 꺼지기 구현

카드 결제 

https://user-images.githubusercontent.com/60956392/183871308-672507cb-6591-44ee-97f7-bdf1d634e861.mov


현금 결제

https://user-images.githubusercontent.com/60956392/183871327-ba2d97e8-7ee3-4c09-b996-6c5a3dff0629.mov


## 🕰 실제 소요 시간

5h

## 📎 관련 이슈

close #59

## 아쉬운 점

서버에서 데이터와 관련된 것들은 스네이크 케이스로 작성했는데, 
프론트에서 이 데이터들을 보내고 받고 하면서 카멜, 스네이크를 일관적이지 못하게 사용해버렸다. 백엔드 변수명을 다 카멜케이스로 바꾸고 싶다.

이번 프로젝트를 하는 2주동안 오늘 짠 코드가 가장 마음에 안든다... 회초리를 원합니다.....

