### PR TITLE
Refactor/70/component

### DIFF
--- a/backend/src/order-to-product/order-to-product.entity.ts
+++ b/backend/src/order-to-product/order-to-product.entity.ts
@@ -1,6 +1,6 @@
 import { Order } from 'src/orders/orders.entity'
 import { Product } from 'src/products/entities/products.entity'
-import { BaseEntity, Column, Entity, JoinColumn, ManyToOne, PrimaryGeneratedColumn } from 'typeorm'
+import { BaseEntity, Column, CreateDateColumn, Entity, JoinColumn, ManyToOne, PrimaryGeneratedColumn } from 'typeorm'
 
 @Entity()
 export class OrderToProduct extends BaseEntity {
@@ -15,6 +15,9 @@ export class OrderToProduct extends BaseEntity {
 
   @Column()
   product_id: number
+
+  @CreateDateColumn()
+  created_at: Date
 
   @ManyToOne(() => Order, (order) => order.orderToProducts)
   @JoinColumn({ name: 'order_id' })

--- a/frontend/src/components/MainPage/Cart/Cart.tsx
+++ b/frontend/src/components/MainPage/Cart/Cart.tsx
@@ -9,6 +9,7 @@ import { useRouter } from 'src/lib/router/Routes'
 import { priceToString } from 'src/utils/priceUtil'
 
 import CartItem from './CartItem'
+import Time from './Time'
 
 const Cart = () => {
   const router = useRouter()
@@ -33,6 +34,7 @@ const Cart = () => {
   return (
     <>
       <Wrapper>
+        <Time />
         <CartListWrapper>
           {cartList.map((cartItem) => (
             <CartItem key={cartItem.cartId} cartItem={cartItem} />

--- a/frontend/src/components/MainPage/Cart/Cart.tsx
+++ b/frontend/src/components/MainPage/Cart/Cart.tsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components'
 
 import Button from 'src/components/common/Button/Button'
-import OrderConfirmModal from 'src/components/common/Modal/OrderConfirmModal'
+import OrderConfirmModal from 'src/components/common/Modal/OrderConfirmModal/OrderConfirmModal'
 import { useCartAction, useCartList, useCartSummary } from 'src/contexts/CartContext'
 import useModal from 'src/hooks/useModal'
 import useTranslation from 'src/hooks/useTranslation'

--- a/frontend/src/components/MainPage/Cart/CartItem.tsx
+++ b/frontend/src/components/MainPage/Cart/CartItem.tsx
@@ -2,7 +2,7 @@ import { FC, useContext } from 'react'
 import styled from 'styled-components'
 
 import Icon from 'src/components/common/Icon/Icon'
-import { Image } from 'src/components/common/Image/Image'
+import Image from 'src/components/common/Image/Image'
 import { CartItemType, MAX_COUNT, MIN_COUNT, useCartAction } from 'src/contexts/CartContext'
 import { InternationalizationContext } from 'src/contexts/InternationalizationContext'
 

--- a/frontend/src/components/MainPage/Cart/Time.tsx
+++ b/frontend/src/components/MainPage/Cart/Time.tsx
@@ -1,0 +1,24 @@
+import styled from 'styled-components'
+
+import useTimer from 'src/hooks/useTimer'
+
+const TIME_SHOW_TRIGGER = 10
+
+const Time = () => {
+  const { time } = useTimer()
+
+  return <TimeText>{time <= TIME_SHOW_TRIGGER && `${time}초 동안 아무런 반응이 없으면 자동으로 종료됩니다.`}</TimeText>
+}
+
+const TimeText = styled.p`
+  margin-bottom: 12px;
+  height: 24px;
+
+  font-size: 24px;
+
+  text-align: end;
+
+  color: ${({ theme }) => theme.color.gray200};
+`
+
+export default Time

--- a/frontend/src/components/MainPage/Menu/Menu.tsx
+++ b/frontend/src/components/MainPage/Menu/Menu.tsx
@@ -1,7 +1,7 @@
 import { FC, useContext, useEffect, useState } from 'react'
 import styled from 'styled-components'
 
-import { Image } from 'src/components/common/Image/Image'
+import Image from 'src/components/common/Image/Image'
 import OptionSelectModal from 'src/components/common/Modal/OptionSelectModal/OptionSelectModal'
 import { InternationalizationContext } from 'src/contexts/InternationalizationContext'
 import useModal from 'src/hooks/useModal'

--- a/frontend/src/components/MainPage/Menu/Menu.tsx
+++ b/frontend/src/components/MainPage/Menu/Menu.tsx
@@ -2,7 +2,7 @@ import { FC, useContext, useEffect, useState } from 'react'
 import styled from 'styled-components'
 
 import { Image } from 'src/components/common/Image/Image'
-import OptionSelectModal from 'src/components/common/Modal/OptionSelectModal'
+import OptionSelectModal from 'src/components/common/Modal/OptionSelectModal/OptionSelectModal'
 import { InternationalizationContext } from 'src/contexts/InternationalizationContext'
 import useModal from 'src/hooks/useModal'
 import { ProductOptionType } from 'src/types/api/product'

--- a/frontend/src/components/MainPage/MenuList/MenuList.tsx
+++ b/frontend/src/components/MainPage/MenuList/MenuList.tsx
@@ -1,8 +1,12 @@
+import { AxiosError } from 'axios'
 import { FC } from 'react'
 import styled from 'styled-components'
 
 import { getProductsAPI } from 'src/api/product/product'
+import ErrorFallback from 'src/components/common/Error/ErrorFallback'
+import { useCartAction } from 'src/contexts/CartContext'
 import { useAxios } from 'src/hooks/useAxios'
+import { useRouter } from 'src/lib/router/Routes'
 import { ProductType } from 'src/types/api/product'
 
 import MenuListSkeleton from './MenuListSkeleton'
@@ -14,9 +18,21 @@ interface Props {
 }
 
 const MenuList: FC<Props> = ({ selected }) => {
-  const { isLoading, data: menuList } = useAxios(['menuList', selected], () => getProductsAPI(selected))
+  const {
+    isLoading,
+    data: menuList,
+    error,
+  } = useAxios<ProductType[], AxiosError>(['menuList', selected], () => getProductsAPI(selected))
+  const router = useRouter()
+  const { clear } = useCartAction()
+  const reset = () => {
+    router('/')
+    clear()
+  }
 
   if (isLoading) return <MenuListSkeleton />
+
+  if (error) return <ErrorFallback reset={reset} message={error.message} />
 
   return (
     <Wrapper>
@@ -38,25 +54,9 @@ const MenuList: FC<Props> = ({ selected }) => {
 export default MenuList
 
 const Wrapper = styled.div`
-  width: calc(100% + 20px);
-  margin-top: 60px;
-
-  height: 894px;
-
-  overflow-y: auto;
+  height: 100%;
 
   display: grid;
   grid-template-columns: repeat(3, 312px);
   gap: 30px;
-
-  &::-webkit-scrollbar {
-    width: 10px;
-    background-color: ${({ theme }) => theme.color.gray100};
-    border-radius: 8px;
-  }
-
-  &::-webkit-scrollbar-thumb {
-    background-color: ${({ theme }) => theme.color.gray500};
-    border-radius: 8px;
-  }
 `

--- a/frontend/src/components/common/Error/ErrorFallback.tsx
+++ b/frontend/src/components/common/Error/ErrorFallback.tsx
@@ -1,0 +1,45 @@
+import React, { FC } from 'react'
+import styled from 'styled-components'
+
+import Button from '../Button/Button'
+
+interface Props {
+  reset: () => void
+  message: string
+}
+
+const ErrorFallback: FC<Props> = ({ reset, message }) => {
+  return (
+    <Wrapper>
+      {/* <ErrorMessage>{message}</ErrorMessage> */}
+      <ErrorMessage>
+        문제가 발생했습니다
+        <br />
+        다시 시도해주세요 🥲
+      </ErrorMessage>
+      <Button bgColor="red" onClick={reset}>
+        초기 화면으로 돌아가기
+      </Button>
+    </Wrapper>
+  )
+}
+
+export default ErrorFallback
+
+const Wrapper = styled.div`
+  width: 100%;
+  height: 100%;
+
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 40px;
+`
+
+const ErrorMessage = styled.p`
+  font-weight: 600;
+  font-size: 32px;
+  line-height: 46px;
+  text-align: center;
+`

--- a/frontend/src/components/common/Image/Image.tsx
+++ b/frontend/src/components/common/Image/Image.tsx
@@ -13,7 +13,7 @@ interface Props {
   onClick?: () => void
 }
 
-export const Image: FC<Props> = ({ name, src, width, height, borderRadius, alt, onClick }) => {
+const Image: FC<Props> = ({ name, src, width, height, borderRadius, alt, onClick }) => {
   const imgSrc = name ? images[name] : src
 
   return (
@@ -22,6 +22,8 @@ export const Image: FC<Props> = ({ name, src, width, height, borderRadius, alt, 
     </ImgWrapper>
   )
 }
+
+export default Image
 
 const ImgWrapper = styled.div<Pick<Props, 'width' | 'height' | 'borderRadius'>>`
   width: ${({ width }) => width && `${width}px`};

--- a/frontend/src/components/common/Modal/CardInputModal/CardInputModal.tsx
+++ b/frontend/src/components/common/Modal/CardInputModal/CardInputModal.tsx
@@ -3,10 +3,9 @@ import styled from 'styled-components'
 
 import useModal from 'src/hooks/useModal'
 
-import Modal from './Modal'
-
-import { Image } from '../Image/Image'
-import PaymentLoader from '../Loader/PaymentLoader'
+import { Image } from '../../Image/Image'
+import PaymentLoader from '../../Loader/PaymentLoader'
+import Modal from '../Modal'
 
 const CARD_DELAY = 2000
 

--- a/frontend/src/components/common/Modal/CardInputModal/CardInputModal.tsx
+++ b/frontend/src/components/common/Modal/CardInputModal/CardInputModal.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components'
 
 import useModal from 'src/hooks/useModal'
 
-import { Image } from '../../Image/Image'
+import Image from '../../Image/Image'
 import PaymentLoader from '../../Loader/PaymentLoader'
 import Modal from '../Modal'
 

--- a/frontend/src/components/common/Modal/CashInputModal/CashInputModal.tsx
+++ b/frontend/src/components/common/Modal/CashInputModal/CashInputModal.tsx
@@ -6,9 +6,8 @@ import useModal from 'src/hooks/useModal'
 import useTranslation from 'src/hooks/useTranslation'
 import { priceToString } from 'src/utils/priceUtil'
 
-import Modal from './Modal'
-
-import PaymentLoader from '../Loader/PaymentLoader'
+import PaymentLoader from '../../Loader/PaymentLoader'
+import Modal from '../Modal'
 
 const CASH_LIST: number[] = [500, 1000, 5000, 10000]
 

--- a/frontend/src/components/common/Modal/OptionSelectModal/OptionItem.tsx
+++ b/frontend/src/components/common/Modal/OptionSelectModal/OptionItem.tsx
@@ -1,0 +1,67 @@
+import React, { FC, useContext } from 'react'
+import styled from 'styled-components'
+
+import { SelectedOptionType } from 'src/contexts/CartContext'
+import { InternationalizationContext } from 'src/contexts/InternationalizationContext'
+import { ProductOptionDetailType, ProductOptionType } from 'src/types/api/product'
+
+interface Props {
+  option: ProductOptionType
+  detail: ProductOptionDetailType
+  selectedOption: SelectedOptionType
+  onClickOptionDetail: (id: number, detail: ProductOptionDetailType) => void
+}
+
+const OptionItem: FC<Props> = ({ option, detail, selectedOption, onClickOptionDetail }) => {
+  const { language } = useContext(InternationalizationContext)
+
+  return (
+    <React.Fragment>
+      <input
+        type="radio"
+        id={`radio-${detail.id}`}
+        value={detail.id}
+        required={option.is_required}
+        checked={selectedOption[option.id]?.detailId === detail.id}
+        readOnly
+        hidden
+      />
+      <OptionDetailLabel
+        htmlFor={`radio-${detail.id}`}
+        key={detail.id}
+        onClick={() => onClickOptionDetail(option.id, detail)}
+      >
+        {language === 'KR' && detail.kr_name}
+        {language === 'EN' && detail.en_name}
+        {detail.price > 0 && <ExtraPrice>+{detail.price}</ExtraPrice>}
+      </OptionDetailLabel>
+    </React.Fragment>
+  )
+}
+
+export default OptionItem
+
+const OptionDetailLabel = styled.label`
+  width: 80px;
+  height: 80px;
+
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+
+  border: 1px solid ${({ theme }) => theme.color.black};
+  border-radius: 24px;
+
+  font-size: 24px;
+  line-height: 140%;
+
+  input[type='radio']:checked + & {
+    border: 2px solid ${({ theme }) => theme.color.red};
+    color: ${({ theme }) => theme.color.red};
+  }
+`
+
+const ExtraPrice = styled.p`
+  font-size: 20px;
+`

--- a/frontend/src/components/common/Modal/OptionSelectModal/OptionList.tsx
+++ b/frontend/src/components/common/Modal/OptionSelectModal/OptionList.tsx
@@ -1,0 +1,57 @@
+import React, { FC, useContext } from 'react'
+import styled from 'styled-components'
+
+import { SelectedOptionType } from 'src/contexts/CartContext'
+import { InternationalizationContext } from 'src/contexts/InternationalizationContext'
+import { ProductOptionDetailType, ProductOptionType } from 'src/types/api/product'
+
+import OptionItem from './OptionItem'
+
+interface Props {
+  selectedOption: SelectedOptionType
+  onClickOptionDetail: (id: number, detail: ProductOptionDetailType) => void
+  options: ProductOptionType[]
+}
+
+const OptionList: FC<Props> = ({ options, selectedOption, onClickOptionDetail }) => {
+  const { language } = useContext(InternationalizationContext)
+
+  return (
+    <>
+      {options.map((option) => (
+        <div key={option.id}>
+          <OptionTitle>
+            {language === 'KR' && option.kr_name}
+            {language === 'EN' && option.en_name}
+            {option.is_required && '*'}
+          </OptionTitle>
+          <OptionDetailList>
+            {option.option_details.map((detail) => (
+              <OptionItem
+                key={detail.id}
+                option={option}
+                detail={detail}
+                selectedOption={selectedOption}
+                onClickOptionDetail={onClickOptionDetail}
+              />
+            ))}
+          </OptionDetailList>
+        </div>
+      ))}
+    </>
+  )
+}
+
+export default OptionList
+
+const OptionTitle = styled.p`
+  font-weight: 600;
+  font-size: 32px;
+  line-height: 140%;
+`
+
+const OptionDetailList = styled.div`
+  margin-top: 14px;
+  display: flex;
+  gap: 32px;
+`

--- a/frontend/src/components/common/Modal/OptionSelectModal/OptionSelectModal.tsx
+++ b/frontend/src/components/common/Modal/OptionSelectModal/OptionSelectModal.tsx
@@ -1,15 +1,14 @@
-import React, { FC, useContext, useState } from 'react'
+import { FC, useState } from 'react'
 import styled from 'styled-components'
 
 import { SelectedOptionType, useCartAction } from 'src/contexts/CartContext'
-import { InternationalizationContext } from 'src/contexts/InternationalizationContext'
 import useCount from 'src/hooks/useCount'
 import useTranslation from 'src/hooks/useTranslation'
 import { ProductOptionDetailType, ProductOptionType } from 'src/types/api/product'
-import { priceToString } from 'src/utils/priceUtil'
 
-import Icon from '../../Icon/Icon'
-import Image from '../../Image/Image'
+import OptionList from './OptionList'
+import ProductSummary from './ProductSummary'
+
 import Modal from '../Modal'
 
 type ExtraPriceType = Record<string, number>
@@ -26,7 +25,6 @@ interface Props {
 }
 
 const OptionSelectModal: FC<Props> = ({ open, onClose, id, imgUrl, krName, enName, price, options }) => {
-  const { language } = useContext(InternationalizationContext)
   const { add } = useCartAction()
   const t = useTranslation('modal')
   const { count, increaseCount, decreaseCount, initCount, isMaxCount, isMinCount } = useCount()
@@ -127,62 +125,21 @@ const OptionSelectModal: FC<Props> = ({ open, onClose, id, imgUrl, krName, enNam
     >
       <Wrapper>
         <LeftSection>
-          <Image src={imgUrl} width={224} height={224} />
-          <ProductName>
-            {language === 'KR' && krName}
-            {language === 'EN' && enName}
-          </ProductName>
-          <ProductPrice>{priceToString((price + extraPriceSum) * count)}</ProductPrice>
-          <CountWrapper>
-            <Icon
-              name="iconCircleMinus"
-              size={36}
-              onClick={onClickMinus}
-              strokeColor={isMinCount ? 'gray300' : 'black'}
-            />
-            <span>{count}</span>
-            <Icon
-              name="iconCirclePlus"
-              size={36}
-              onClick={onClickPlus}
-              strokeColor={isMaxCount ? 'gray300' : 'black'}
-            />
-          </CountWrapper>
+          <ProductSummary
+            imgUrl={imgUrl}
+            krName={krName}
+            enName={enName}
+            price={price}
+            extraPrice={extraPriceSum}
+            count={count}
+            isMinCount={isMinCount}
+            isMaxCount={isMaxCount}
+            onClickMinus={onClickMinus}
+            onClickPlus={onClickPlus}
+          />
         </LeftSection>
         <RightSection>
-          {options.map((option) => (
-            <div key={option.id}>
-              <OptionTitle>
-                {language === 'KR' && option.kr_name}
-                {language === 'EN' && option.en_name}
-                {option.is_required && '*'}
-              </OptionTitle>
-              <OptionDetailList>
-                {option.option_details.map((detail) => (
-                  <React.Fragment key={detail.id}>
-                    <input
-                      type="radio"
-                      id={`radio-${detail.id}`}
-                      value={detail.id}
-                      required={option.is_required}
-                      checked={selectedOption[option.id]?.detailId === detail.id}
-                      readOnly
-                      hidden
-                    />
-                    <OptionDetailLabel
-                      htmlFor={`radio-${detail.id}`}
-                      key={detail.id}
-                      onClick={() => onClickOptionDetail(option.id, detail)}
-                    >
-                      {language === 'KR' && detail.kr_name}
-                      {language === 'EN' && detail.en_name}
-                      {detail.price > 0 && <ExtraPrice>+{detail.price}</ExtraPrice>}
-                    </OptionDetailLabel>
-                  </React.Fragment>
-                ))}
-              </OptionDetailList>
-            </div>
-          ))}
+          <OptionList options={options} selectedOption={selectedOption} onClickOptionDetail={onClickOptionDetail} />
         </RightSection>
       </Wrapper>
     </Modal>
@@ -204,74 +161,8 @@ const LeftSection = styled.div`
   align-items: center;
 `
 
-const ProductName = styled.p`
-  margin-top: 14px;
-  font-weight: 600;
-  font-size: 32px;
-  line-height: 140%;
-  ${({ theme }) => theme.color.black}
-`
-
-const ProductPrice = styled.p`
-  margin-top: 8px;
-  font-size: 32px;
-  line-height: 140%;
-  ${({ theme }) => theme.color.black}
-`
-
-const CountWrapper = styled.div`
-  display: flex;
-  align-items: center;
-  gap: 20px;
-
-  span {
-    width: 30px;
-    font-weight: 600;
-    font-size: 48px;
-    line-height: 57px;
-    text-align: center;
-  }
-`
-
 const RightSection = styled.div`
   display: flex;
   flex-direction: column;
   gap: 30px;
-`
-
-const OptionTitle = styled.p`
-  font-weight: 600;
-  font-size: 32px;
-  line-height: 140%;
-`
-
-const OptionDetailList = styled.div`
-  margin-top: 14px;
-  display: flex;
-  gap: 32px;
-`
-
-const OptionDetailLabel = styled.label`
-  width: 80px;
-  height: 80px;
-
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-
-  border: 1px solid ${({ theme }) => theme.color.black};
-  border-radius: 24px;
-
-  font-size: 24px;
-  line-height: 140%;
-
-  input[type='radio']:checked + & {
-    border: 2px solid ${({ theme }) => theme.color.red};
-    color: ${({ theme }) => theme.color.red};
-  }
-`
-
-const ExtraPrice = styled.p`
-  font-size: 20px;
 `

--- a/frontend/src/components/common/Modal/OptionSelectModal/OptionSelectModal.tsx
+++ b/frontend/src/components/common/Modal/OptionSelectModal/OptionSelectModal.tsx
@@ -8,10 +8,9 @@ import useTranslation from 'src/hooks/useTranslation'
 import { ProductOptionDetailType, ProductOptionType } from 'src/types/api/product'
 import { priceToString } from 'src/utils/priceUtil'
 
-import Modal from './Modal'
-
-import Icon from '../Icon/Icon'
-import { Image } from '../Image/Image'
+import Icon from '../../Icon/Icon'
+import { Image } from '../../Image/Image'
+import Modal from '../Modal'
 
 type ExtraPriceType = Record<string, number>
 

--- a/frontend/src/components/common/Modal/OptionSelectModal/OptionSelectModal.tsx
+++ b/frontend/src/components/common/Modal/OptionSelectModal/OptionSelectModal.tsx
@@ -9,7 +9,7 @@ import { ProductOptionDetailType, ProductOptionType } from 'src/types/api/produc
 import { priceToString } from 'src/utils/priceUtil'
 
 import Icon from '../../Icon/Icon'
-import { Image } from '../../Image/Image'
+import Image from '../../Image/Image'
 import Modal from '../Modal'
 
 type ExtraPriceType = Record<string, number>

--- a/frontend/src/components/common/Modal/OptionSelectModal/ProductSummary.tsx
+++ b/frontend/src/components/common/Modal/OptionSelectModal/ProductSummary.tsx
@@ -1,0 +1,83 @@
+import React, { FC, useContext } from 'react'
+import styled from 'styled-components'
+
+import { InternationalizationContext } from 'src/contexts/InternationalizationContext'
+import { priceToString } from 'src/utils/priceUtil'
+
+import Icon from '../../Icon/Icon'
+import Image from '../../Image/Image'
+
+interface Props {
+  imgUrl: string
+  krName: string
+  enName: string
+  price: number
+  extraPrice: number
+  count: number
+  isMinCount: boolean
+  isMaxCount: boolean
+  onClickMinus: () => void
+  onClickPlus: () => void
+}
+
+const ProductSummary: FC<Props> = ({
+  imgUrl,
+  krName,
+  enName,
+  price,
+  extraPrice,
+  count,
+  isMaxCount,
+  isMinCount,
+  onClickMinus,
+  onClickPlus,
+}) => {
+  const { language } = useContext(InternationalizationContext)
+
+  return (
+    <>
+      <Image src={imgUrl} width={224} height={224} />
+      <ProductName>
+        {language === 'KR' && krName}
+        {language === 'EN' && enName}
+      </ProductName>
+      <ProductPrice>{priceToString((price + extraPrice) * count)}</ProductPrice>
+      <CountWrapper>
+        <Icon name="iconCircleMinus" size={36} onClick={onClickMinus} strokeColor={isMinCount ? 'gray300' : 'black'} />
+        <span>{count}</span>
+        <Icon name="iconCirclePlus" size={36} onClick={onClickPlus} strokeColor={isMaxCount ? 'gray300' : 'black'} />
+      </CountWrapper>
+    </>
+  )
+}
+
+export default ProductSummary
+
+const ProductName = styled.p`
+  margin-top: 14px;
+  font-weight: 600;
+  font-size: 32px;
+  line-height: 140%;
+  ${({ theme }) => theme.color.black}
+`
+
+const ProductPrice = styled.p`
+  margin-top: 8px;
+  font-size: 32px;
+  line-height: 140%;
+  ${({ theme }) => theme.color.black}
+`
+
+const CountWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 20px;
+
+  span {
+    width: 30px;
+    font-weight: 600;
+    font-size: 48px;
+    line-height: 57px;
+    text-align: center;
+  }
+`

--- a/frontend/src/components/common/Modal/OrderConfirmModal/OrderConfirmModal.tsx
+++ b/frontend/src/components/common/Modal/OrderConfirmModal/OrderConfirmModal.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useContext } from 'react'
+import React, { FC, useContext, useEffect } from 'react'
 import styled from 'styled-components'
 
 import { CartItemType, MAX_COUNT, MIN_COUNT, useCartAction, useCartList } from 'src/contexts/CartContext'
@@ -44,6 +44,12 @@ const OrderConfirmModal: FC<Props> = ({ open, onClose }) => {
     onOpenPaymentMethodModal()
     onClose()
   }
+
+  useEffect(() => {
+    if (cartList.length !== 0) return
+
+    onClose()
+  }, [cartList])
 
   return (
     <>

--- a/frontend/src/components/common/Modal/OrderConfirmModal/OrderConfirmModal.tsx
+++ b/frontend/src/components/common/Modal/OrderConfirmModal/OrderConfirmModal.tsx
@@ -7,10 +7,9 @@ import useModal from 'src/hooks/useModal'
 import useTranslation from 'src/hooks/useTranslation'
 import { priceToString } from 'src/utils/priceUtil'
 
-import Modal from './Modal'
-import PaymentMethodModal from './PaymentMethodModal'
-
-import Icon from '../Icon/Icon'
+import Icon from '../../Icon/Icon'
+import Modal from '../Modal'
+import PaymentMethodModal from '../PaymentMethodModal/PaymentMethodModal'
 
 interface Props {
   open: boolean

--- a/frontend/src/components/common/Modal/PaymentMethodModal/PaymentMethodModal.tsx
+++ b/frontend/src/components/common/Modal/PaymentMethodModal/PaymentMethodModal.tsx
@@ -1,4 +1,4 @@
-import { FC, useState } from 'react'
+import { FC } from 'react'
 import styled from 'styled-components'
 
 import { useCartSummary } from 'src/contexts/CartContext'
@@ -6,11 +6,10 @@ import useModal from 'src/hooks/useModal'
 import useTranslation from 'src/hooks/useTranslation'
 import { priceToString } from 'src/utils/priceUtil'
 
-import CardInputModal from './CardInputModal'
-import CashInputModal from './CashInputModal'
-import Modal from './Modal'
-
-import Icon from '../Icon/Icon'
+import Icon from '../../Icon/Icon'
+import CardInputModal from '../CardInputModal/CardInputModal'
+import CashInputModal from '../CashInputModal/CashInputModal'
+import Modal from '../Modal'
 
 interface Props {
   open: boolean

--- a/frontend/src/hooks/useTimer.ts
+++ b/frontend/src/hooks/useTimer.ts
@@ -1,0 +1,42 @@
+import { useEffect, useState } from 'react'
+
+import { useCartAction } from 'src/contexts/CartContext'
+import { useRouter } from 'src/lib/router/Routes'
+
+const TIME = 30
+
+const useTimer = () => {
+  const router = useRouter()
+  const { clear } = useCartAction()
+  const [time, setTime] = useState(TIME)
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setTime((prev) => prev - 1)
+    }, 1000)
+
+    return () => {
+      clearInterval(interval)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (time === 0) {
+      router('/')
+      clear()
+    }
+
+    const resetTime = () => {
+      setTime(TIME)
+    }
+
+    window.addEventListener('mouseup', resetTime)
+    return () => {
+      window.removeEventListener('mouseup', resetTime)
+    }
+  }, [time])
+
+  return { time }
+}
+
+export default useTimer

--- a/frontend/src/pages/Main.tsx
+++ b/frontend/src/pages/Main.tsx
@@ -17,7 +17,9 @@ const Main = () => {
     <Wrapper>
       <Header />
       <CategoryTabs selected={selectedCategoryId} onClickCategory={onClickCategory} />
-      <MenuList selected={selectedCategoryId} />
+      <MenuListWrapper>
+        <MenuList selected={selectedCategoryId} />
+      </MenuListWrapper>
       <Cart />
     </Wrapper>
   )
@@ -29,4 +31,24 @@ const Wrapper = styled.div`
   height: 100%;
   position: relative;
   padding: 0 42px;
+`
+
+const MenuListWrapper = styled.div`
+  margin-top: 60px;
+
+  width: calc(100% + 20px);
+
+  height: 894px;
+  overflow-y: auto;
+
+  &::-webkit-scrollbar {
+    width: 10px;
+    background-color: ${({ theme }) => theme.color.gray100};
+    border-radius: 8px;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background-color: ${({ theme }) => theme.color.gray500};
+    border-radius: 8px;
+  }
 `


### PR DESCRIPTION
## 📑 개요

옵션 선택 모달 컴포넌트 파일 분리

## 💬 작업 내용

`order to product` 테이블에 `created_at` 컬럼 추가

옵션 선택 모달 컴포넌트 파일 분리
옵션 선택 모달 -> 옵션 선택 모달, 좌측 상품 정보 컴포넌트, 우측 옵션 선택 컴포넌트

30초 타이머 구현

30초 안에 `mouseup` 이벤트 발생 시, 타이머 초기화

state로 time을 관리하는 이유 : 몇 초 남았는지 유저에게 보여주기 위함.


서버 에러 Error Fallback 구현

<img width="426" alt="스크린샷 2022-08-11 오전 10 52 29" src="https://user-images.githubusercontent.com/60956392/184053765-755e7d36-aefe-41d6-bfef-6ebd9c352c71.png">



한 PR에 backend, frontend, feature, refactor 다 있네요 하하!

## 🕰 실제 소요 시간

1h 30m

## 📎 관련 이슈

close #70 

